### PR TITLE
2.5.9

### DIFF
--- a/feed-them.php
+++ b/feed-them.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social (Facebook, Instagram, Twitter, etc)
  * Plugin URI: https://feedthemsocial.com/
  * Description: Customize feeds for Facebook Pages, Album Photos, Videos & Covers, Instagram, Twitter, Pinterest & YouTube on pages, posts or widgets.
- * Version: 2.5.8
+ * Version: 2.5.9
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 4.0.0
  * Tested up to: WordPress 4.9.8
- * Stable tag: 2.5.8
+ * Stable tag: 2.5.9
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    2.5.8
+ * @version    2.5.9
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2018 SlickRemix
  *
@@ -31,7 +31,7 @@
  *
  * Makes sure any js or css changes are reloaded properly. Added to enqued css and js files throughout!
  */
-define( 'FTS_CURRENT_VERSION', '2.5.8' );
+define( 'FTS_CURRENT_VERSION', '2.5.9' );
 
 define( 'FEED_THEM_SOCIAL_NOTICE_STATUS', get_option( 'rating_fts_slick_notice', false ) );
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: slickremix
 Tags: Facebook, Instagram, Twitter, YouTube, Feed
 Requires at least: 3.6.0
 Tested up to: 4.9.8
-Stable tag: 2.5.8
+Stable tag: 2.5.9
 License: GPLv2 or later
 
 Custom feeds for Facebook Pages, Album Photos, Videos & Covers, Instagram, Twitter, Pinterest & YouTube on pages, posts or widgets.
@@ -76,7 +76,7 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
   * Log into WordPress dashboard then click **Plugins** > **Add new** > Then under the title "Install Plugins" click **Upload** > **choose the zip** > **Activate the plugin!**
 
 == Changelog ==
-= Version 2.5.8 Monday, October 22nd, 2018 =
+= Version 2.5.8 - 2.5.9 Monday, October 22nd, 2018 =
    * NEW: Facebook Options: Translate the text, View on Facebook.
    * FIX: Pinterest & Instagram Options: Some plugins stripping out the hashtag we used to pass the access token in the browser url. Now we use &access_token instead.
    * FIX: Instagram hashtag feed: The set image count was not responding.


### PR DESCRIPTION
 Version 2.5.8 - 2.5.9 Monday, October 22nd, 2018 =
   * NEW: Facebook Options: Translate the text, View on Facebook.
   * FIX: Pinterest & Instagram Options: Some plugins stripping out the hashtag we used to pass the access token in the browser url. Now we use &access_token instead.
   * FIX: Instagram hashtag feed: The set image count was not responding.
   * FIX: YoutTube Options: Access token not being saved properly.
   * FIX: Misc style updates.
   * COMBINED STREAMS NEW: Version 1.1.8: More rigorous error check in place to make sure if one social network fails the rest of the feed does not go down. Also admin notices will appear for social networks that are not working and give you instructions on what to check for to fix the problem.