### PR TITLE
2.6.3

### DIFF
--- a/admin/class-fts-instagram-options-page.php
+++ b/admin/class-fts-instagram-options-page.php
@@ -96,11 +96,6 @@ class FTS_Instagram_Options_Page {
 						echo esc_html( 'This is required to make the Instagram Feed work. Click the button below and it will connect to your Instagram Account to get an access token. It will then return to this page and save it in the inputs below. After it finishes you will be able to generate your Instagram feed.', 'feed-them-social' );
                         ?>
 						</p>
-                        <p>
-                            <?php
-                            echo esc_html( 'If you need to generate more than one feed simply remove the Instagram ID and Access Token and click the Save All Changes button at the bottom of the page. Make sure you are logged out of your current Instagram Account and click the button to get a new access token. You will be prompted to login to Instagram with your new account username and password. Once the new access token is returned you can then create another feed.', 'feed-them-social' );
-                            ?>
-                        </p>
 						<p>
 						<?php
 						echo sprintf(

--- a/admin/class-fts-settings-page-options.php
+++ b/admin/class-fts-settings-page-options.php
@@ -1155,7 +1155,7 @@ class FTS_Settings_Page_Options {
 						'label'       => __( 'Facebook ID (required)', 'feed-them-social' ),
 						'instructional-text' => array(
 							array(
-								'text' => __( 'If your Access Token is set on the Facebook Options page of our plugin your ID should appear below. To create an additional feed go back the' ) . ' <a href="admin.php?page=fts-facebook-feed-styles-submenu-page" target="_blank">' . __( 'Facebook Options', 'feed-them-social' ) . '</a> ' . __( 'page and make sure you are logged into that specific Facebook account then click the button again to get a new Access Token/ID. Remember to click Save all Changes and return here.', 'feed-them-social' ) . '',
+								'text' => __( 'If your Access Token is set on the Facebook Options page of our plugin your ID should appear below.', 'feed-them-social' ),
 								'class' => 'facebook-message-generator page inst-text-facebook-page',
 							),
 							array(
@@ -1175,16 +1175,16 @@ class FTS_Settings_Page_Options {
 								'class' => 'facebook-message-generator album_photos inst-text-facebook-album-photos',
 							),
 							array(
-								'text' => __( 'If your Access Token is set on the Facebook Options page of our plugin your ID should appear below. To create an additional feed go back the' ) . ' <a href="admin.php?page=fts-facebook-feed-styles-submenu-page" target="_blank">' . __( 'Facebook Options', 'feed-them-social' ) . '</a> ' . __( 'page and make sure you are logged into that specific Facebook account then click the button again to get a new Access Token/ID. Remember to click Save all Changes and return here.', 'feed-them-social' ) . '',
-								'class' => 'facebook-message-generator albums inst-text-facebook-albums',
+                                'text' => __( 'If your Access Token is set on the Facebook Options page of our plugin your ID should appear below.', 'feed-them-social' ),
+                                'class' => 'facebook-message-generator albums inst-text-facebook-albums',
 							),
 							array(
-								'text' => __( 'If your Access Token is set on the Facebook Options page of our plugin your ID should appear below. To create an additional feed go back the' ) . ' <a href="admin.php?page=fts-facebook-feed-styles-submenu-page" target="_blank">' . __( 'Facebook Options', 'feed-them-social' ) . '</a> ' . __( 'page and make sure you are logged into that specific Facebook account then click the button again to get a new Access Token/ID. Remember to click Save all Changes and return here.', 'feed-them-social' ) . '',
-								'class' => 'facebook-message-generator video inst-text-facebook-video',
+                                'text' => __( 'If your Access Token is set on the Facebook Options page of our plugin your ID should appear below.', 'feed-them-social' ),
+                                'class' => 'facebook-message-generator video inst-text-facebook-video',
 							),
 							array(
-								'text' => __( 'If your Access Token is set on the Facebook Options page of our plugin your ID should appear below. To create an additional feed go back the' ) . ' <a href="admin.php?page=fts-facebook-feed-styles-submenu-page" target="_blank">' . __( 'Facebook Options', 'feed-them-social' ) . '</a> ' . __( 'page and make sure you are logged into that specific Facebook account then click the button again to get a new Access Token/ID. Remember to click Save all Changes and return here.', 'feed-them-social' ) . '',
-								'class' => 'facebook-message-generator reviews inst-text-facebook-reviews',
+                                'text' => __( 'If your Access Token is set on the Facebook Options page of our plugin your ID should appear below.', 'feed-them-social' ),
+                                'class' => 'facebook-message-generator reviews inst-text-facebook-reviews',
 							),
 						),
 						'type'        => 'text',
@@ -1201,25 +1201,25 @@ class FTS_Settings_Page_Options {
 					),
 
 					// Access Token
-					array(
-						'option_type' => 'input',
-						'label'       => __( 'Access Token (required) ', 'feed-them-social' ) . '<br/><small>' . __( '', 'feed-them-social' ) . '</small>',
-						'type'        => 'text',
-						'id'          => 'fb_access_token',
-						'name'        => 'fb_access_token',
+			//		array(
+			//			'option_type' => 'input',
+			//			'label'       => __( 'Access Token (required) ', 'feed-them-social' ) . '<br/><small>' . __( '', 'feed-them-social' ) . '</small>',
+			//			'type'        => 'text',
+			//			'id'          => 'fb_access_token',
+			//			'name'        => 'fb_access_token',
 
 						// Only needed if Prem_Req = More otherwise remove (must have array key req_plugin)
 						// 'prem_req_more_msg' => '<br/><small>' . __('More than 6 Requires <a target="_blank" href="https://www.slickremix.com/downloads/feed-them-social-premium-extension/">Premium version</a>', 'feed-them-social') . '</small>',
-						'placeholder' => __( '', 'feed-them-social' ),
+			//			'placeholder' => __( '', 'feed-them-social' ),
 
 						// Relative to JS.
-						'short_attr'  => array(
-							'attr_name'    => 'access_token',
-							'var_final_if' => 'yes',
-							'empty_error'  => 'set',
-							'empty_error_value' => '',
-						),
-					),
+			//			'short_attr'  => array(
+			//				'attr_name'    => 'access_token',
+			//				'var_final_if' => 'yes',
+			//				'empty_error'  => 'set',
+			//				'empty_error_value' => '',
+			//			),
+			//		),
 
 					// Facebook Album ID
 					array(
@@ -4398,8 +4398,8 @@ class FTS_Settings_Page_Options {
 						'required'    => 'yes',
 						'instructional-text' => array(
 							1 => array(
-								'text' => __( '<div class="fts-insta-info-plus-wrapper">If your Access Token is set on the Instagram Options page of our plugin your ID should appear below.<br/><strong>To create an additional feed</strong> go back the ', 'feed-them-social' ) . ' <a href="admin.php?page=fts-instagram-feed-styles-submenu-page" target="">' . __( 'Instagram Options', 'feed-them-social' ) . '</a>' . __( ' and make sure you are logged into that specific Instagram account then click the button again to get a new Access Token/ID. Remember to click Save all Changes and return here.</div>', 'feed-them-social' ),
-								'class' => 'instagram-user-option-text',
+                                'text' => __( '<div class="fts-insta-info-plus-wrapper">If your Access Token is set on the Instagram Options page of our plugin your ID should appear below.</div>', 'feed-them-social' ),
+                                'class' => 'instagram-user-option-text',
 							),
 							2 => array(
 								'text' => __( 'Add your Hashtag below. <strong>DO NOT</strong> add the #, just the name.', 'feed-them-social' ),
@@ -4420,25 +4420,25 @@ class FTS_Settings_Page_Options {
 					),
 
 					// Access Token
-					array(
-						'option_type' => 'input',
-						'label'       => __( 'Access Token (required) ', 'feed-them-social' ) . '<br/><small>' . __( '', 'feed-them-social' ) . '</small>',
-						'type'        => 'text',
-						'id'          => 'insta_access_token',
-						'name'        => 'insta_access_token',
+			//		array(
+			//			'option_type' => 'input',
+			//			'label'       => __( 'Access Token (required) ', 'feed-them-social' ) . '<br/><small>' . __( '', 'feed-them-social' ) . '</small>',
+			//			'type'        => 'text',
+			//			'id'          => 'insta_access_token',
+			//			'name'        => 'insta_access_token',
 
 						// Only needed if Prem_Req = More otherwise remove (must have array key req_plugin)
 						// 'prem_req_more_msg' => '<br/><small>' . __('More than 6 Requires <a target="_blank" href="https://www.slickremix.com/downloads/feed-them-social-premium-extension/">Premium version</a>', 'feed-them-social') . '</small>',
-						'placeholder' => __( '', 'feed-them-social' ),
+			//			'placeholder' => __( '', 'feed-them-social' ),
 
 						// Relative to JS.
-						'short_attr'  => array(
-							'attr_name'    => 'access_token',
-							'var_final_if' => 'yes',
-							'empty_error'  => 'set',
-							'empty_error_value' => '',
-						),
-					),
+			//			'short_attr'  => array(
+			//				'attr_name'    => 'access_token',
+			//				'var_final_if' => 'yes',
+			//				'empty_error'  => 'set',
+			//				'empty_error_value' => '',
+			//			),
+			//		),
 
 					// Pic Count
 					array(

--- a/feed-them.php
+++ b/feed-them.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social (Facebook, Instagram, Twitter, etc)
  * Plugin URI: https://feedthemsocial.com/
  * Description: Customize feeds for Facebook Pages, Album Photos, Videos & Covers, Instagram, Twitter, Pinterest & YouTube on pages, posts or widgets.
- * Version: 2.6.2
+ * Version: 2.6.3
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 4.0.0
- * Tested up to: WordPress 5.0.1
- * Stable tag: 2.6.2
+ * Tested up to: WordPress 5.0.3
+ * Stable tag: 2.6.3
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    2.6.2
+ * @version    2.6.3
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2019 SlickRemix
  *
@@ -31,7 +31,7 @@
  *
  * Makes sure any js or css changes are reloaded properly. Added to enqued css and js files throughout!
  */
-define( 'FTS_CURRENT_VERSION', '2.6.2' );
+define( 'FTS_CURRENT_VERSION', '2.6.3' );
 
 define( 'FEED_THEM_SOCIAL_NOTICE_STATUS', get_option( 'rating_fts_slick_notice', false ) );
 

--- a/feeds/facebook/class-fts-facebook-feed.php
+++ b/feeds/facebook/class-fts-facebook-feed.php
@@ -113,7 +113,7 @@ class FTS_Facebook_Feed extends feed_them_social_functions {
 					'show_media'               => '',
 					'show_date'                => '',
 					'show_name'                => '',
-					'access_token'             => '',
+				//	'access_token'             => '',
 
 				),
 				$atts
@@ -140,7 +140,7 @@ class FTS_Facebook_Feed extends feed_them_social_functions {
 					'image_position_lr'        => '',
 					'image_position_top'       => '',
 					'hide_comments_popup'      => '',
-					'access_token'             => '',
+				//	'access_token'             => '',
 
 				),
 				$atts
@@ -164,12 +164,12 @@ class FTS_Facebook_Feed extends feed_them_social_functions {
 		}
 
 		// Get Access Token.
-		$access_token = isset( $fb_shortcode['access_token'] ) ? $fb_shortcode['access_token'] : '';
-		if ( ! empty( $access_token ) ) {
-			$access_token = $fb_shortcode['access_token'];
-		} else {
+	//	$access_token = isset( $fb_shortcode['access_token'] ) ? $fb_shortcode['access_token'] : '';
+	//	if ( ! empty( $access_token ) ) {
+	//		$access_token = $fb_shortcode['access_token'];
+	//	} else {
 			$access_token = $this->get_access_token();
-		}
+	//	}
 
 		// UserName?.
 		if ( ! $fb_shortcode['id'] ) {
@@ -1599,6 +1599,10 @@ style="margin:' . ( isset( $fb_shortcode['slider_margin'] ) && '' !== $fb_shortc
 			if ( 'page' === $fb_shortcode['type'] && 'page_only' === $fb_shortcode['posts_displayed'] ) {
 				$mulit_data = array( 'page_data' => 'https://graph.facebook.com/' . $fb_shortcode['id'] . '?fields=id,name,description&access_token=' . $access_token . $language . '' );
 
+                if(isset($_REQUEST['next_url'])){
+                    $_REQUEST['next_url'] = str_replace( 'access_token=XXX', 'access_token='.get_option('fts_facebook_custom_api_token'), $_REQUEST['next_url'] );
+                }
+
 				if ( ! $fts_count_ids >= 1 ) {
 					// We cannot add sanitize_text_field here on the $_REQUEST['next_url'] otherwise it will fail to load the contents from the facebook API.
 					$mulit_data['feed_data'] = isset( $_REQUEST['next_url'] ) ? esc_url_raw( $_REQUEST['next_url'] ) : esc_url_raw( 'https://graph.facebook.com/' . $fb_shortcode['id'] . '/posts?fields=id,caption,attachments,created_time,description,from,icon,link,message,name,object_id,picture,full_picture,place,shares,source,status_type,story,to,type&limit=' . $fb_shortcode['posts'] . '&access_token=' . $access_token . $language . '' );
@@ -2022,10 +2026,14 @@ style="margin:' . ( isset( $fb_shortcode['slider_margin'] ) && '' !== $fb_shortc
 
 			// Load More BUTTON Start.
 			$next_url       = isset( $feed_data->paging->next ) ? $feed_data->paging->next : '';
+
 			$posts          = isset( $fb_shortcode['posts'] ) ? $fb_shortcode['posts'] : '';
 			$loadmore_count = isset( $fb_shortcode['loadmore_count'] ) && '' !== $fb_shortcode['loadmore_count'] ? $fb_shortcode['loadmore_count'] : '';
 			// we check to see if the loadmore count number is set and if so pass that as the new count number when fetching the next set of posts.
 			$_REQUEST['next_url'] = '' !== $loadmore_count ? str_replace( "limit=$posts", "limit=$loadmore_count", $next_url ) : $next_url;
+
+			$access_token = 'access_token='.get_option( 'fts_facebook_custom_api_token' );
+            $_REQUEST['next_url'] = str_replace( $access_token, "access_token=XXX", $next_url );
 
 			echo '<script>';
 			echo 'var nextURL_' . esc_js( $_REQUEST['fts_dynamic_name'] ) . '= "' . esc_url_raw( $_REQUEST['next_url'] ) . '";';

--- a/feeds/instagram/class-fts-instagram-feed.php
+++ b/feeds/instagram/class-fts-instagram-feed.php
@@ -282,7 +282,7 @@ class FTS_Instagram_Feed extends feed_them_social_functions {
 							'profile_description'      => '',
 							'columns'                  => '',
 							'force_columns'            => '',
-							'access_token'             => '',
+							// 'access_token'             => '',
 						),
 						$atts
 					)
@@ -343,6 +343,9 @@ class FTS_Instagram_Feed extends feed_them_social_functions {
 				$fts_instagram_access_token_final = $access_token;
 			}
 
+            if(isset($_REQUEST['next_url'])){
+                $_REQUEST['next_url'] = str_replace( 'access_token=XXX', 'access_token='.get_option('fts_instagram_custom_api_token'), $_REQUEST['next_url'] );
+            }
 			// $instagram_id comes from our shortcode.
 			// URL to get Feeds.
 			if ( 'hashtag' === $type ) {
@@ -802,6 +805,10 @@ if ( 'yes' === $profile_description ) {
                 $next_url = isset( $insta_data->pagination->next_url ) ? $insta_data->pagination->next_url : '';
                 // we check to see if the loadmore count number is set and if so pass that as the new count number when fetching the next set of pics/videos.
                 $_REQUEST['next_url'] = ! empty( $loadmore_count ) ? str_replace( "count=$pics_count", "count=$loadmore_count", $next_url ) : $next_url;
+
+                $access_token = 'access_token='.get_option( 'fts_instagram_custom_api_token' );
+                $_REQUEST['next_url'] = str_replace( $access_token, "access_token=XXX", $next_url );
+
                 ?>
         <script>var nextURL_<?php echo esc_js( sanitize_text_field( wp_unslash( $_REQUEST['fts_dynamic_name'] ) ) ); ?>= "<?php echo esc_url_raw( $_REQUEST['next_url'] ); ?>";</script>
                 <?php

--- a/feeds/js/fts-global-full.js
+++ b/feeds/js/fts-global-full.js
@@ -1,7 +1,6 @@
 jQuery(document).ready(function() {
 
 
-
     jQuery('.fts-youtube-scrollable, .youtube-comments-wrap-premium, .youtube-comments-thumbs').hover(function() {
         jQuery("body").css("overflow","hidden");
     }, function() {

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: slickremix
 Tags: Facebook, Instagram, Twitter, YouTube, Feed
 Requires at least: 3.6.0
-Tested up to: 5.0.1
-Stable tag: 2.6.2
+Tested up to: 5.0.3
+Stable tag: 2.6.3
 License: GPLv2 or later
 
 Custom feeds for Facebook Pages, Album Photos, Videos & Covers, Instagram, Twitter, Pinterest & YouTube on pages, posts or widgets.
@@ -75,6 +75,9 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
   * Log into WordPress dashboard then click **Plugins** > **Add new** > Then under the title "Install Plugins" click **Upload** > **choose the zip** > **Activate the plugin!**
 
 == Changelog ==
+= Version 2.6.3 Wednesday, February 5th, 2018 =
+   * FIX: Facebook & Instagram Feed: Remove the access_token= option in the shortcode. Unfortunately this is a security risk to your access token if our plugin is not active. This means if you had multiple feeds using different access tokens those feeds will not work anymore. We are working on creating a custom post type for the feeds so you will be able to do this but for now we need to remove the option. Very sorry for the any inconveniences this may cause you, but rest assured we will be back with an even easier method using the custom post type.
+
 = Version 2.6.2 Saturday, December 15th, 2018 =
    * FIX: Instagram Feed: Incorrect CSS for Videos.
 


### PR DESCRIPTION
= Version 2.6.3 Wednesday, February 5th, 2018 =
   * FIX: All Facebook & Instagram Feeds: Remove the access_token= option in the shortcode. Unfortunately this is a security risk to your access token if our plugin is not active. This means if you had multiple feeds using different access tokens those feeds will not work anymore. We are working on creating a custom post type for the feeds so you will be able to do this but for now we need to remove the option. Very sorry for the any inconveniences this may cause you, but rest assured we will be back with an even easier method using the custom post type.