### PR TITLE
2.6.5

### DIFF
--- a/feed-them.php
+++ b/feed-them.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social (Facebook, Instagram, Twitter, etc)
  * Plugin URI: https://feedthemsocial.com/
  * Description: Customize feeds for Facebook Pages, Album Photos, Videos & Covers, Instagram, Twitter, Pinterest & YouTube on pages, posts or widgets.
- * Version: 2.6.4
+ * Version: 2.6.5
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 4.0.0
  * Tested up to: WordPress 5.0.3
- * Stable tag: 2.6.4
+ * Stable tag: 2.6.5
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    2.6.4
+ * @version    2.6.5
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2019 SlickRemix
  *
@@ -31,7 +31,7 @@
  *
  * Makes sure any js or css changes are reloaded properly. Added to enqued css and js files throughout!
  */
-define( 'FTS_CURRENT_VERSION', '2.6.4' );
+define( 'FTS_CURRENT_VERSION', '2.6.5' );
 
 define( 'FEED_THEM_SOCIAL_NOTICE_STATUS', get_option( 'rating_fts_slick_notice', false ) );
 

--- a/feeds/facebook/class-fts-facebook-feed-post-types.php
+++ b/feeds/facebook/class-fts-facebook-feed-post-types.php
@@ -184,6 +184,10 @@ class FTS_Facebook_Feed_Post_Types extends FTS_Facebook_Feed {
 		// Count Likes/Shares/.
 		$lcs_array = $this->get_likes_shares_comments( $response_post_array, $post_data_key, $fb_post_share_count );
 
+		//echo '<pre>';
+        //print_r($lcs_array);
+        //echo '</pre>';
+
 		$fb_location  = isset( $post_data->location ) ? $post_data->location : '';
 		$fb_embed_vid = isset( $post_data->embed_html ) ? $post_data->embed_html : '';
 		$fb_from_name = isset( $post_data->from->name ) ? $post_data->from->name : '';
@@ -303,7 +307,7 @@ class FTS_Facebook_Feed_Post_Types extends FTS_Facebook_Feed {
 
 				echo '<div class="fts-jal-fb-user-thumb">';
 
-				echo ( 'reviews' === esc_attr( $fb_shortcode['type'] ) ? '' : '<a href="https://www.facebook.com/' . esc_attr( $post_data->from->id ) . '" target="_blank">' ) . '<img border="0" alt="' . ( 'reviews' === esc_attr( $fb_shortcode['type'] ) ? esc_attr( $post_data->reviewer->name ) : esc_attr( $post_data->from->name ) ) . '" src="https://graph.facebook.com/' . ( 'reviews' === esc_attr( $fb_shortcode['type'] ) ? esc_attr( $post_data->reviewer->id ) : esc_attr( $post_data->from->id ) ) . '/picture"/></a>' . ( 'reviews' === esc_attr( $fb_shortcode['type'] ) ? '' : '</a>' );
+				echo ( 'reviews' === esc_attr( $fb_shortcode['type'] ) ? '' : '<a href="https://www.facebook.com/' . esc_attr( $post_data->from->id ) . '" target="_blank">' ) . '<img border="0" alt="' . ( 'reviews' === esc_attr( $fb_shortcode['type'] ) ? esc_attr( $post_data->reviewer->name ) : esc_attr( $post_data->from->name ) ) . '" src="' . ( 'reviews' === esc_attr( $fb_shortcode['type'] ) ? esc_url( $post_data->fts_profile_pic_url ) : 'https://graph.facebook.com/' .esc_attr( $post_data->from->id ) ) . '/picture"/></a>' . ( 'reviews' === esc_attr( $fb_shortcode['type'] ) ? '' : '</a>' );
 
 				echo '</div>';
 
@@ -690,7 +694,7 @@ class FTS_Facebook_Feed_Post_Types extends FTS_Facebook_Feed {
 						}
 					}
 					// srl: 8/27/17 - FB BUG: for some reason the full_picture for animated gifs is not correct so we dig deeper and grab another image size fb has set.
-					if ( 'animated_image_video' === $post_data->attachments->data[0]->type ) {
+					if ( isset($post_data->attachments->data[0]->type) && 'animated_image_video' === $post_data->attachments->data[0]->type ) {
 						$vid_pic = $post_data->attachments->data[0]->media->image->src;
 					} else {
 						$vid_pic = $post_data->full_picture;
@@ -1000,18 +1004,20 @@ class FTS_Facebook_Feed_Post_Types extends FTS_Facebook_Feed {
 				echo '<div class="fts-fb-comments-content fts-comments-post-' . esc_attr( $fb_post_id ) . '">';
 
 				foreach ( $lcs_array['comments_thread']->data as $comment ) {
-					echo '<div class="fts-fb-comment fts-fb-comment-' . esc_attr( $comment->id ) . '">';
-					// User Profile Img.
-					$avatar_id = isset( $comment->from->id ) ? $comment->from->id : '118790751525884';
-					echo '<img class="fts-fb-comment-user-pic" src="' . esc_url( 'https://graph.facebook.com/' . $avatar_id . '/picture?type=square' ) . '"/>';
-					echo '<div class="fts-fb-comment-msg">';
-					if ( isset( $comment->from->name ) ) {
-						echo '<span class="fts-fb-comment-user-name">' . esc_html( $comment->from->name ) . '</span> ';
-					}
-					echo esc_html( $comment->message ) . '</div>';
+				    if(!empty($comment->message)) {
+                        echo '<div class="fts-fb-comment fts-fb-comment-' . esc_attr( $comment->id ) . '">';
+                        // User Profile Img.
+                        $avatar_id = isset( $comment->from->id ) ? $comment->from->id : '118790751525884';
+                        echo '<img class="fts-fb-comment-user-pic" src="' . esc_url( 'https://graph.facebook.com/' . $avatar_id . '/picture?type=square' ) . '"/>';
+                        echo '<div class="fts-fb-comment-msg">';
+                        if ( isset( $comment->from->name ) ) {
+                            echo '<span class="fts-fb-comment-user-name">' . esc_html( $comment->from->name ) . '</span> ';
+                        }
+                        echo esc_html( $comment->message ) . '</div>';
 
-					// Comment Message.
-					echo '</div>';
+                        // Comment Message.
+                        echo '</div>';
+                    }
 				}
 				echo '</div>';
 			}

--- a/feeds/facebook/class-fts-facebook-feed.php
+++ b/feeds/facebook/class-fts-facebook-feed.php
@@ -318,10 +318,16 @@ class FTS_Facebook_Feed extends feed_them_social_functions {
 			$response = $this->get_facebook_feed_response( $fb_shortcode, $fb_cache_name, $biz_access_token, $language );
 
 			$feed_data = json_decode( $response['feed_data'] );
+
+            $feed_data = (object) $feed_data;
+            // Add Feed Type to post array.
+
 			// SHOW THE REVIEWS FEED PRINT_R
 			// echo '<pre>';
 			// print_r($feed_data );
-			// echo '</pre>';.
+			// echo '</pre>';
+
+
 			if ( 'yes' === $fb_shortcode['remove_reviews_no_description'] ) {
 				// $no_description_count2 = 0;.
 				foreach ( $feed_data->data as $k => $v ) {
@@ -333,10 +339,27 @@ class FTS_Facebook_Feed extends feed_them_social_functions {
 				}
 			}
 			$ratings_data = json_decode( $response['ratings_data'] );
+
 			// SHOW THE REVIEWS RATING INFO PRINT_R
 			// echo '<pre>';
 			// print_r($ratings_data );
 			// echo '</pre>';.
+
+            // Add fts_profile_pic_url to the array so we can show profile photos for reviews and comments in popup
+            foreach ( $feed_data->data as $post_array ) {
+
+                $the_image = 'https://graph.facebook.com/'.$post_array->reviewer->id.'/picture?redirect=false&access_token='.$biz_access_token.'';
+
+                $profile_pic_response = wp_remote_get($the_image );
+                $profile_pic_data = wp_remote_retrieve_body( $profile_pic_response );
+                $profile_pic_output = json_decode( $profile_pic_data );
+
+                  //  echo '<pre>';
+                  //  print_r($profile_pic_output->data->url);
+                  //  echo '</pre>';
+
+                $post_array->fts_profile_pic_url = $profile_pic_output->data->url;
+            }
 		}
 
 		if ( is_plugin_active( 'feed-them-social-combined-streams/feed-them-social-combined-streams.php' ) ) {
@@ -1652,7 +1675,11 @@ style="margin:' . ( isset( $fb_shortcode['slider_margin'] ) && '' !== $fb_shortc
 					$fts_facebook_reviews = new FTS_Facebook_Reviews();
 					$mulit_data           = $fts_facebook_reviews->review_connection( $fb_shortcode, $access_token, $language );
 
+					// I THINK THIS IS WHERE WE NEED TO DO ANOTHER CONNECTION TO GET THE REVIEWS IMAGES NOW THAT FACEBOOK CHANGED MORE STUFF
+                    // CODE GOES HERE
+
 					$mulit_data['ratings_data'] = esc_url_raw( 'https://graph.facebook.com/' . $fb_shortcode['id'] . '/?fields=overall_star_rating,rating_count&access_token=' . $access_token . '' );
+
 
 				} else {
 					return 'Please Purchase and Activate the Feed Them Social Reviews plugin.';

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: slickremix
 Tags: Facebook, Instagram, Twitter, YouTube, Feed
 Requires at least: 3.6.0
 Tested up to: 5.0.3
-Stable tag: 2.6.4
+Stable tag: 2.6.5
 License: GPLv2 or later
 
 Custom feeds for Facebook Pages, Album Photos, Videos & Covers, Instagram, Twitter, Pinterest & YouTube on pages, posts or widgets.
@@ -75,6 +75,11 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
   * Log into WordPress dashboard then click **Plugins** > **Add new** > Then under the title "Install Plugins" click **Upload** > **choose the zip** > **Activate the plugin!**
 
 == Changelog ==
+= Version 2.6.5 Monday, February 18th, 2018 =
+   * FIX: Facebook Feed: php warning: unset call for $post_data->attachments->data[0]->type
+   * FB REVIEWS EXTENSION: Profile photos of reviewers visible again (recent changes to the API was why the images disappeared).
+   * NOTE TO PREMIUM USERS: The profile and or name for comments in the popup cannot be retrieved at this time do to privacy changes with Facebook. If the user has there profile public the profile and username will appear.
+
 = Version 2.6.4 Thursday, February 7th, 2018 =
    * FIX: Instagram Feed: Feed not displaying correctly.
 


### PR DESCRIPTION
= Version 2.6.5 Monday, February 18th, 2018 =
   * FIX: Facebook Feed: php warning: unset call for $post_data->attachments->data[0]->type
   * FB REVIEWS EXTENSION: Profile photos of reviewers visible again (recent changes to the API was why the images disappeared).
   * NOTE TO PREMIUM USERS: The profile and or name for comments in the popup cannot be retrieved at this time do to privacy changes with Facebook. If the user has there profile public the profile and username will appear.