### PR TITLE
2.6.8

### DIFF
--- a/admin/class-fts-instagram-options-page.php
+++ b/admin/class-fts-instagram-options-page.php
@@ -101,7 +101,7 @@ class FTS_Instagram_Options_Page {
                         // state=' . admin_url( 'admin.php?page-fts has a dash instead of equals otherwise instagram will chop our return url so on the return instagram page on our server we change it back to = so the token can be retrieved fts v2.6.7.
 						echo sprintf(
 							esc_html( '%1$sLogin and get my Access Token%2$s', 'feed-them-social' ),
-							'<a href="' . esc_url( 'https://instagram.com/oauth/authorize/?client_id=da06fb6699f1497bb0d5d4234a50da75&scope=public_content&redirect_uri=https://www.slickremix.com/instagram-token-plugin/?return_uri=' . admin_url( 'admin.php?page=fts-instagram-feed-styles-submenu-page' ) . '&response_type=token&state=' . admin_url( 'admin.php?page-fts-instagram-feed-styles-submenu-page' ) . '' ) . '" class="fts-instagram-get-access-token">',
+							'<a href="' . esc_url( 'https://instagram.com/oauth/authorize/?client_id=da06fb6699f1497bb0d5d4234a50da75&hl=en&scope=public_content&redirect_uri=https://www.slickremix.com/instagram-token-plugin/?return_uri=' . admin_url( 'admin.php?page=fts-instagram-feed-styles-submenu-page' ) . '&response_type=token&state=' . admin_url( 'admin.php?page-fts-instagram-feed-styles-submenu-page' ) . '' ) . '" class="fts-instagram-get-access-token">',
 							'</a>'
 						);
 						?>

--- a/feed-them.php
+++ b/feed-them.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social (Facebook, Instagram, Twitter, etc)
  * Plugin URI: https://feedthemsocial.com/
  * Description: Customize feeds for Facebook Pages, Album Photos, Videos & Covers, Instagram, Twitter, Pinterest & YouTube on pages, posts or widgets.
- * Version: 2.6.7
+ * Version: 2.6.8
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 4.0.0
- * Tested up to: WordPress 5.1
- * Stable tag: 2.6.7
+ * Tested up to: WordPress 5.1.1
+ * Stable tag: 2.6.8
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    2.6.7
+ * @version    2.6.8
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2019 SlickRemix
  *
@@ -31,7 +31,7 @@
  *
  * Makes sure any js or css changes are reloaded properly. Added to enqued css and js files throughout!
  */
-define( 'FTS_CURRENT_VERSION', '2.6.7' );
+define( 'FTS_CURRENT_VERSION', '2.6.8' );
 
 define( 'FEED_THEM_SOCIAL_NOTICE_STATUS', get_option( 'rating_fts_slick_notice', false ) );
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: slickremix
 Tags: Facebook, Instagram, Twitter, YouTube, Feed
 Requires at least: 3.6.0
-Tested up to: 5.1
-Stable tag: 2.6.7
+Tested up to: 5.1.1
+Stable tag: 2.6.8
 License: GPLv2 or later
 
 Custom feeds for Facebook Pages, Album Photos, Videos & Covers, Instagram, Twitter, Pinterest & YouTube on pages, posts or widgets.
@@ -75,6 +75,9 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
   * Log into WordPress dashboard then click **Plugins** > **Add new** > Then under the title "Install Plugins" click **Upload** > **choose the zip** > **Activate the plugin!**
 
 == Changelog ==
+= Version 2.6.8 Wednesday, April 3rd, 2019 =
+   * FIX: Instagram Options page: Button to get an access token if your browser was not in english would fail. We have added hl=en to the url now to address this issue. We are aware this will force the authorization box to be in english but until Instagram fixes this issue it is the only work around.
+
 = Version 2.6.7 Wednesday, March 13th, 2019 =
    * FIX: Pinterest Feed: Add alt tag to img elements.
    * FIX: Facebook & Twitter Feed: Links with underscores, @mentions_withUnderscore, #mentions_withUnderscore now are complete links.


### PR DESCRIPTION
= Version 2.6.8 Wednesday, April 3rd, 2019 =
   * FIX: Instagram Options page: Button to get an access token if your browser was not in english would fail. We have added hl=en to the url now to address this issue. We are aware this will force the authorization box to be in english but until Instagram fixes this issue it is the only work around.