### PR TITLE
2.6.9

### DIFF
--- a/feed-them.php
+++ b/feed-them.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social (Facebook, Instagram, Twitter, etc)
  * Plugin URI: https://feedthemsocial.com/
  * Description: Customize feeds for Facebook Pages, Album Photos, Videos & Covers, Instagram, Twitter, Pinterest & YouTube on pages, posts or widgets.
- * Version: 2.6.8
+ * Version: 2.6.9
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 4.0.0
- * Tested up to: WordPress 5.1.1
- * Stable tag: 2.6.8
+ * Tested up to: WordPress 5.2
+ * Stable tag: 2.6.9
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    2.6.8
+ * @version    2.6.9
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2019 SlickRemix
  *
@@ -31,7 +31,7 @@
  *
  * Makes sure any js or css changes are reloaded properly. Added to enqued css and js files throughout!
  */
-define( 'FTS_CURRENT_VERSION', '2.6.8' );
+define( 'FTS_CURRENT_VERSION', '2.6.9' );
 
 define( 'FEED_THEM_SOCIAL_NOTICE_STATUS', get_option( 'rating_fts_slick_notice', false ) );
 

--- a/feeds/facebook/class-fts-facebook-feed.php
+++ b/feeds/facebook/class-fts-facebook-feed.php
@@ -653,7 +653,9 @@ style="margin:' . ( isset( $fb_shortcode['slider_margin'] ) && '' !== $fb_shortc
 		$set_zero = 0;
 
 		// echo '<br/><br/>feed array<br/><br/>';.
-		// print_r( $feed_data );.
+        // echo '<pre>';
+        // print_r($feed_data );
+        // echo '</pre>';
 		// THE MAIN FEED
 		// LOOP to fix Post count!
 		foreach ( $feed_data->data as $k => $v ) {
@@ -1660,9 +1662,9 @@ style="margin:' . ( isset( $fb_shortcode['slider_margin'] ) && '' !== $fb_shortc
 				// The reason I did not create a whole new else if for the video album is because I did not want to duplicate all the code required to make the video because the videos gallery comes from the photo albums on facebook.
 				if ( isset( $fb_shortcode['video_album'] ) && 'yes' === $fb_shortcode['video_album'] ) {
 					if ( ! $fts_count_ids >= 1 ) {
-						$mulit_data['feed_data'] = isset( $_REQUEST['next_url'] ) ? esc_url_raw( $_REQUEST['next_url'] ) : esc_url_raw( 'https://graph.facebook.com/' . $fb_shortcode['id'] . '/videos?fields=id,created_time,description,from,icon,link,message,object_id,picture,place,shares,source,to,type,format,embed_html&limit=' . $fb_shortcode['posts'] . '&access_token=' . $access_token . $language . '' );
+						$mulit_data['feed_data'] = isset( $_REQUEST['next_url'] ) ? esc_url_raw( $_REQUEST['next_url'] ) : esc_url_raw( 'https://graph.facebook.com/' . $fb_shortcode['id'] . '/videos?fields=id,created_time,description,from,icon,link,message,object_id,picture,place,source,to,type,format,embed_html&limit=' . $fb_shortcode['posts'] . '&access_token=' . $access_token . $language . '' );
 					} else {
-						$mulit_data['feed_data'] = isset( $_REQUEST['next_url'] ) ? esc_url_raw( $_REQUEST['next_url'] ) : esc_url_raw( 'https://graph.facebook.com/videos?ids=' . $fb_shortcode['id'] . '&fields=id,created_time,description,from,icon,link,message,object_id,picture,place,shares,source,to,type,format,embed_html&limit=' . $fb_shortcode['posts'] . '&access_token=' . $access_token . $language . '' );
+						$mulit_data['feed_data'] = isset( $_REQUEST['next_url'] ) ? esc_url_raw( $_REQUEST['next_url'] ) : esc_url_raw( 'https://graph.facebook.com/videos?ids=' . $fb_shortcode['id'] . '&fields=id,created_time,description,from,icon,link,message,object_id,picture,place,source,to,type,format,embed_html&limit=' . $fb_shortcode['posts'] . '&access_token=' . $access_token . $language . '' );
 					}
 				} elseif ( isset( $fb_shortcode['album_id'] ) && 'photo_stream' === $fb_shortcode['album_id'] ) {
 					if ( ! $fts_count_ids >= 1 ) {

--- a/feeds/twitter/class-fts-twitter-feed.php
+++ b/feeds/twitter/class-fts-twitter-feed.php
@@ -194,7 +194,7 @@ class FTS_Twitter_Feed extends feed_them_social_functions {
 		$text = isset( $post_data->retweeted_status->full_text ) ? $post_data->retweeted_status->full_text : $post_data->full_text;
 
 		// Message. Convert links to real links.
-		$pattern   = array( '/http:(\S)+/', '/https:(\S)+/', '/[@]+([0-9\p{L}]+)/u', '/[#]+([0-9\p{L}]+)/u' );
+		$pattern   = array( '/http:(\S)+/', '/https:(\S)+/', '/@+(\w+)/u', '/#+(\w+)/u' );
 		$replace   = array( ' <a href="${0}" target="_blank" rel="nofollow">${0}</a>', ' <a href="${0}" target="_blank" rel="nofollow">${0}</a>', ' <a href="https://twitter.com/$1" target="_blank" rel="nofollow">@$1</a>', ' <a href="https://twitter.com/hashtag/$1?src=hash" target="_blank" rel="nofollow">#$1</a>' );
 		$full_text = preg_replace( $pattern, $replace, $text );
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: slickremix
 Tags: Facebook, Instagram, Twitter, YouTube, Feed
 Requires at least: 3.6.0
-Tested up to: 5.1.1
-Stable tag: 2.6.8
+Tested up to: 5.2
+Stable tag: 2.6.9
 License: GPLv2 or later
 
 Custom feeds for Facebook Pages, Album Photos, Videos & Covers, Instagram, Twitter, Pinterest & YouTube on pages, posts or widgets.
@@ -75,6 +75,10 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
   * Log into WordPress dashboard then click **Plugins** > **Add new** > Then under the title "Install Plugins" click **Upload** > **choose the zip** > **Activate the plugin!**
 
 == Changelog ==
+= Version 2.6.9 Wednesday, May 17th, 2019 =
+   * FIX: Twitter Feed: Fixed links with underscores to work proper, such as; #my_hashtag or @my_name.
+   * PREMIUM FIX: Facebook Videos Feed: Removed shares from the edge for the API call. Shares has been depreciated and was making video feeds fail to load properly.
+
 = Version 2.6.8 Wednesday, April 3rd, 2019 =
    * FIX: Instagram Options page: Button to get an access token if your browser was not in english would fail. We have added hl=en to the url now to address this issue. We are aware this will force the authorization box to be in english but until Instagram fixes this issue it is the only work around.
 


### PR DESCRIPTION
= Version 2.6.9 Wednesday, May 17th, 2019 =
   * FIX: Twitter Feed: Fixed links with underscores to work proper, such as; #my_hashtag or @my_name.
   * PREMIUM FIX: Facebook Videos Feed: Removed shares from the edge for the API call. Shares has been depreciated and was making video feeds fail to load properly.