### PR TITLE
version 2.7.1 - Fix Access token error message

### DIFF
--- a/feed-them.php
+++ b/feed-them.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social (Facebook, Instagram, Twitter, etc)
  * Plugin URI: https://feedthemsocial.com/
  * Description: Customize feeds for Facebook Pages, Album Photos, Videos & Covers, Instagram, Twitter, Pinterest & YouTube on pages, posts or widgets.
- * Version: 2.7.0
+ * Version: 2.7.1
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 4.0.0
  * Tested up to: WordPress 5.2
- * Stable tag: 2.7.0
+ * Stable tag: 2.7.1
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    2.7.0
+ * @version    2.7.1
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2019 SlickRemix
  *
@@ -31,7 +31,7 @@
  *
  * Makes sure any js or css changes are reloaded properly. Added to enqued css and js files throughout!
  */
-define( 'FTS_CURRENT_VERSION', '2.7.0' );
+define( 'FTS_CURRENT_VERSION', '2.7.1' );
 
 define( 'FEED_THEM_SOCIAL_NOTICE_STATUS', get_option( 'rating_fts_slick_notice', false ) );
 


### PR DESCRIPTION
= Version 2.7.1 Monday, July 16th, 2019 =
   * ADD: Twitter Error messages only show for Logged in Admins now.
   * FIX: Twitter Access Tokens Error message and check.
   * FIX: Twitter Access Tokens now save on Option Page in the admin automatically when returned from Twitter Authorization page instead of having to click the "Save" button after return. This prevents confusion with Access token check.
