### PR TITLE
2.8.3.3

### DIFF
--- a/admin/class-fts-pinterest-options-page.php
+++ b/admin/class-fts-pinterest-options-page.php
@@ -37,7 +37,14 @@ class FTS_Pinterest_Options_Page {
 		$fts_pinterest_show_follow_btn_where = get_option( 'pinterest_show_follow_btn_where' );
         $access_token         = isset( $_GET['access_token'] ) ? sanitize_text_field( $_GET['access_token'] ) : get_option( 'fts_pinterest_custom_api_token' );
 		?>
-		<div class="feed-them-social-admin-wrap">
+        <div class="fts-failed-api-token" style="margin-bottom: 20px;">
+            <?php
+            echo esc_html( 'Without notice or warning the Pinterest API has become unavailable. Once the API is available to us again we will make an update to correct the issue. For the time being we are going to disable the access token button. 4-20-2020', 'feed-them-social' );
+            ?>
+        </div>
+
+        <div class="feed-them-social-admin-wrap">
+
 			<h1>
 				<?php echo esc_html( 'Pinterest Feed Options', 'feed-them-social' ); ?>
 			</h1>
@@ -56,11 +63,12 @@ class FTS_Pinterest_Options_Page {
 
 				<?php settings_fields( 'fts-pinterest-feed-style-options' ); ?>
 
-				<div class="feed-them-social-admin-input-wrap" style="padding-top:0">
+				<div class="feed-them-social-admin-input-wrap" style="padding-top:0; display: noneee">
 					<div class="fts-title-description-settings-page">
 						<h3>
 							<?php echo esc_html( 'Pinterest Access Token', 'feed-them-social' ); ?>
 						</h3>
+
 						<p><?php echo esc_html( 'This is required to make the feed work. Click the button below and it will connect to your Pinterest account to get an access token, and it will return it in the input below. Then click the save button and you will now be able to generate your Pinterest feed from the Settings page of our plugin.', 'feed-them-social' ); ?>
 						</p>
 						<p>

--- a/admin/class-fts-system-info-page.php
+++ b/admin/class-fts-system-info-page.php
@@ -132,7 +132,8 @@ Cache time: <?php echo esc_html( $this->fts_cachetime_amount( $fts_cachetime ) )
 			$twitter_options2  = get_option( 'fts_twitter_custom_consumer_secret' ) ? 'Yes' : 'No';
 			$twitter_options3  = get_option( 'fts_twitter_custom_access_token' ) ? 'Yes' : 'No';
 			$twitter_options4  = get_option( 'fts_twitter_custom_access_token_secret' ) ? 'Yes' : 'No';
-			$instagram_options = get_option( 'fts_instagram_custom_api_token' ) ? 'Yes' : 'No';
+			$instagram_basic_token = get_option( 'fts_instagram_custom_api_token' ) ? 'Yes' : 'No';
+            $instagram_business_token = get_option( 'fts_instagram_custom_api_token' ) ? 'Yes' : 'No';
 			$pinterest_token   = get_option( 'fts_pinterest_custom_api_token' ) ? 'Yes' : 'No';
 
 			$fts_date_time_format = get_option( 'fts-date-and-time-format' ) ? get_option( 'fts-date-and-time-format' ) : 'No';
@@ -161,7 +162,8 @@ Twitter Secret:             <?php echo esc_html( $twitter_options2 ) . "\n"; ?>
 Twitter Token:              <?php echo esc_html( $twitter_options3 ) . "\n"; ?>
 Twitter Token Secret:       <?php echo esc_html( $twitter_options4 ) . "\n"; ?>
 Pinterest Token:            <?php echo esc_html( $pinterest_token ) . "\n"; ?>
-Instagram: 		    <?php echo esc_html( $instagram_options ) . "\n";
+Instagram Basic Token:      <?php echo esc_html( $instagram_basic_token ) . "\n"; ?>
+Instagram Business Token:   <?php echo esc_html( $instagram_business_token ) . "\n";
 		$youtube_options                               = get_option( 'youtube_custom_api_token' ) || get_option( 'youtube_custom_access_token' ) && get_option( 'youtube_custom_refresh_token' ) && get_option( 'youtube_custom_token_exp_time' ) ? 'Yes' : 'No';
 		$fts_fix_loadmore                              = get_option( 'fts_fix_loadmore' ) ? get_option( 'fts_fix_loadmore' ) : 'No';
 		$feed_them_social_premium_license_key          = get_option( 'feed_them_social_premium_license_key' );

--- a/feed-them.php
+++ b/feed-them.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social - for Twitter feed, Youtube, Pinterest and more
  * Plugin URI: https://feedthemsocial.com/
  * Description: Display a Custom Facebook feed, Instagram feed, Twitter feed, Pinterest feed & YouTube feed on pages, posts or widgets.
- * Version: 2.8.3.2
+ * Version: 2.8.3.3
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 4.0.0
  * Tested up to: WordPress 5.4.0
- * Stable tag: 2.8.3.2
+ * Stable tag: 2.8.3.3
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    2.8.3.2
+ * @version    2.8.3.3
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2020 SlickRemix
  *
@@ -31,7 +31,7 @@
  *
  * Makes sure any js or css changes are reloaded properly. Added to enqued css and js files throughout!
  */
-define( 'FTS_CURRENT_VERSION', '2.8.3.2' );
+define( 'FTS_CURRENT_VERSION', '2.8.3.3' );
 
 define( 'FEED_THEM_SOCIAL_NOTICE_STATUS', get_option( 'rating_fts_slick_notice', false ) );
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: slickremix, slickchris
 Tags: Facebook, Instagram, Twitter, YouTube, Feed
 Requires at least: 3.6.0
 Tested up to: 5.4.0
-Stable tag: 2.8.3.2
+Stable tag: 2.8.3.3
 License: GPLv2 or later
 
 Display a Custom Facebook feed, Instagram feed, Twitter feed, Pinterest feed & YouTube feed on pages, posts or widgets.
@@ -75,6 +75,10 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
   * Log into WordPress dashboard then click **Plugins** > **Add new** > Then under the title "Install Plugins" click **Upload** > **choose the zip** > **Activate the plugin!**
 
 == Changelog ==
+= Version 2.8.3.3 Monday, April 20th, 2020 =
+  * REMOVED: Pinterest Feed: Without notice or warning the Pinterest API has become unavailable. Once the API is available to us again we will make an update to correct the issue. For the time being we are going to disable the access token button.
+  * NEW: System Info: Added Instgram Basic and Business token checks to aid in support.
+
 = Version 2.8.3.2 Wednesday, April 8th, 2020 =
   * FIXED: Instagram Feed: Profile info options not showing on the Settings page shortcode generator, follow button was not displaying and misspelling of Instagram name on legacy API error message.
 

--- a/readme.txt
+++ b/readme.txt
@@ -76,7 +76,7 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
 
 == Changelog ==
 = Version 2.8.3.3 Monday, April 20th, 2020 =
-  * REMOVED: Pinterest Feed: Without notice or warning the Pinterest API has become unavailable. Once the API is available to us again we will make an update to correct the issue. For the time being we are going to disable the access token button.
+  * DISABLED: Pinterest Feed: Without notice or warning the Pinterest API has become unavailable. Once the API is available to us again we will make an update to correct the issue. For the time being we are going to disable the access token button.
   * NEW: System Info: Added Instgram Basic and Business token checks to aid in support.
 
 = Version 2.8.3.2 Wednesday, April 8th, 2020 =


### PR DESCRIPTION
= Version 2.8.3.3 Tuesday, April 28th, 2020 =
  * DISABLED: Pinterest Feed: Without notice or warning the Pinterest API has become unavailable. Once the API is available to us again we will make an update to correct the issue. For the time being we are going to disable the access token button.
  * NEW: System Info: Added Instgram Basic and Business token checks to aid in support.