### PR TITLE
2.8.6

### DIFF
--- a/feed-them.php
+++ b/feed-them.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social - for Twitter feed, Youtube, Pinterest and more
  * Plugin URI: https://feedthemsocial.com/
  * Description: Display a Custom Facebook feed, Instagram feed, Twitter feed, Pinterest feed & YouTube feed on pages, posts or widgets.
- * Version: 2.8.5
+ * Version: 2.8.6
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 4.0.0
  * Tested up to: WordPress 5.4.2
- * Stable tag: 2.8.5
+ * Stable tag: 2.8.6
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    2.8.5
+ * @version    2.8.6
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2020 SlickRemix
  *
@@ -31,7 +31,7 @@
  *
  * Makes sure any js or css changes are reloaded properly. Added to enqued css and js files throughout!
  */
-define( 'FTS_CURRENT_VERSION', '2.8.5' );
+define( 'FTS_CURRENT_VERSION', '2.8.6' );
 
 define( 'FEED_THEM_SOCIAL_NOTICE_STATUS', get_option( 'rating_fts_slick_notice', false ) );
 


### PR DESCRIPTION
= Version 2.8.6 Thursday, July 23rd, 2020 =
  * NEW: Facebook Feed: All target="_blank" a tag elements now have rel="noreferrer" for better SEO results.
  * NEW: Facebook Options: Option to change the main page title htag (h1-h6) and font size.
  * REMOVE: Facebook Albums Feed: Date the Album was created.
  * PREMIUM NEW: Facebook Albums: Now you can see 25 photos per album using the popup option.
  * PREMIUM FIX: Facebook Feed:
  * PREMIUM FIX: Add h6 in the list of tags to avoid appending the ellipsis. This works when using the words=45 shortcode option.
  * FACEBOOK REVIEWS FIX: If no profile photo set on Facebook use our default fts icon so the profile image does not appear broken.