### PR TITLE
Use WP_PLUGIN_DIR to prevent fatal errors

### DIFF
--- a/admin/class-fts-twitter-options-page.php
+++ b/admin/class-fts-twitter-options-page.php
@@ -101,7 +101,7 @@ class FTS_Twitter_Options_Page {
 
 					if ( isset( $_GET['page'] ) && 'fts-twitter-feed-styles-submenu-page' === $_GET['page'] ) {
 
-						include WP_CONTENT_DIR . '/plugins/feed-them-social/feeds/twitter/twitteroauth/twitteroauth.php';
+						include WP_PLUGIN_DIR . '/feed-them-social/feeds/twitter/twitteroauth/twitteroauth.php';
 
 						$test_connection = new TwitterOAuthFTS(
 							// Consumer Key!

--- a/feeds/facebook/class-fts-facebook-feed.php
+++ b/feeds/facebook/class-fts-facebook-feed.php
@@ -78,7 +78,7 @@ class FTS_Facebook_Feed extends feed_them_social_functions {
 			// Load up some scripts for popup.
 			$this->load_popup_scripts( $fb_shortcode );
 		} elseif ( is_plugin_active( 'feed-them-premium/feed-them-premium.php' ) ) {
-			include WP_CONTENT_DIR . '/plugins/feed-them-premium/feeds/facebook/facebook-premium-feed.php';
+			include WP_PLUGIN_DIR . '/feed-them-premium/feeds/facebook/facebook-premium-feed.php';
 			// Doing this to phase out the invalid snake case.
 			$fb_shortcode = $FB_Shortcode;
 			// Load up some scripts for popup.

--- a/feeds/instagram/class-fts-instagram-feed.php
+++ b/feeds/instagram/class-fts-instagram-feed.php
@@ -296,7 +296,7 @@ class FTS_Instagram_Feed extends feed_them_social_functions {
 
 			include_once ABSPATH . 'wp-admin/includes/plugin.php';
 			if ( is_plugin_active( 'feed-them-premium/feed-them-premium.php' ) ) {
-				include WP_CONTENT_DIR . '/plugins/feed-them-premium/feeds/instagram/instagram-feed.php';
+				include WP_PLUGIN_DIR . '/feed-them-premium/feeds/instagram/instagram-feed.php';
 				// $popup variable comes from the premium version
 				if ( isset( $popup ) && 'yes' === $popup ) {
 					// it's ok if these styles & scripts load at the bottom of the page.

--- a/feeds/pinterest/class-fts-pinterest-feed.php
+++ b/feeds/pinterest/class-fts-pinterest-feed.php
@@ -129,7 +129,7 @@ class FTS_Pinterest_Feed extends feed_them_social_functions {
 
 		// Premium Plugin.
 		if ( is_plugin_active( 'feed-them-premium/feed-them-premium.php' ) ) {
-			include WP_CONTENT_DIR . '/plugins/feed-them-premium/feeds/pinterest/pinterest-feed.php';
+			include WP_PLUGIN_DIR . '/feed-them-premium/feeds/pinterest/pinterest-feed.php';
 		} else {
 			extract(
 				shortcode_atts(

--- a/feeds/twitter/class-fts-twitter-feed.php
+++ b/feeds/twitter/class-fts-twitter-feed.php
@@ -329,7 +329,7 @@ class FTS_Twitter_Feed extends feed_them_social_functions {
 				$twitter_load_more_text      = get_option( 'twitter_load_more_text' ) ? get_option( 'twitter_load_more_text' ) : __( 'Load More', 'feed-them-social' );
 				$twitter_no_more_tweets_text = get_option( 'twitter_no_more_tweets_text' ) ? get_option( 'twitter_no_more_tweets_text' ) : __( 'No More Tweets', 'feed-them-social' );
 
-				include WP_CONTENT_DIR . '/plugins/feed-them-premium/feeds/twitter/twitter-feed.php';
+				include WP_PLUGIN_DIR . '/feed-them-premium/feeds/twitter/twitter-feed.php';
 
 				if ( isset( $popup ) && 'yes' === $popup ) {
 					// it's ok if these styles & scripts load at the bottom of the page.
@@ -398,7 +398,7 @@ class FTS_Twitter_Feed extends feed_them_social_functions {
 				$fetched_tweets = $this->fts_get_feed_cache( $data_cache );
 				$cache_used     = true;
 			} else {
-				include_once WP_CONTENT_DIR . '/plugins/feed-them-social/feeds/twitter/twitteroauth/twitteroauth.php';
+				include_once WP_PLUGIN_DIR . '/feed-them-social/feeds/twitter/twitteroauth/twitteroauth.php';
 
 				$fts_twitter_custom_consumer_key    = get_option( 'fts_twitter_custom_consumer_key' );
 				$fts_twitter_custom_consumer_secret = get_option( 'fts_twitter_custom_consumer_secret' );

--- a/feeds/youtube/class-youtube-feed-free.php
+++ b/feeds/youtube/class-youtube-feed-free.php
@@ -97,7 +97,7 @@ class FTS_Youtube_Feed_Free extends feed_them_social_functions {
 				include_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 				if ( is_plugin_active( 'feed-them-premium/feed-them-premium.php' ) ) {
-					include WP_CONTENT_DIR . '/plugins/feed-them-premium/feeds/youtube/youtube-feed.php';
+					include WP_PLUGIN_DIR . '/feed-them-premium/feeds/youtube/youtube-feed.php';
 				} else {
 					extract(
 						shortcode_atts(


### PR DESCRIPTION
Prevent PHP fatal errors if plugins are moved to custom directory.

Fixes #109 