### PR TITLE
2.8.8

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -77,7 +77,7 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
 == Changelog ==
 = Version 2.8.8 Thursday, September 17th, 2020 =
   * TESTED: Tested plugin with WordPress version 5.5.1.
-  * FIX: FACEBOOK & INSTAGRAM OPTIONS PAGE: manage_pages permission is depreciatted in favor of pages_show_list. This is required when going through the login flow allowing you to choose the facebok business pages you are an admin of that you want to get an access token for.
+  * FIX: FACEBOOK & INSTAGRAM OPTIONS PAGE: manage_pages permission is deprecated in favor of pages_show_list. This is required when going through the login flow allowing you to choose the facebook business pages you are an admin of that you want to get an access token for.
 
 = Version 2.8.7 Tuesday, August 25th, 2020 =
   * TESTED: Tested plugin with WordPress version 5.5.0.


### PR DESCRIPTION
= Version 2.8.8 Thursday, September 17th, 2020 =
  * TESTED: Tested plugin with WordPress version 5.5.1.
  * FIX: FACEBOOK & INSTAGRAM OPTIONS PAGE: manage_pages permission is deprecated in favor of pages_show_list. This is required when going through the login flow allowing you to choose the facebook business pages you are an admin of that you want to get an access token for.