### PR TITLE
2.8.9

### DIFF
--- a/admin/class-fts-facebook-options-page.php
+++ b/admin/class-fts-facebook-options-page.php
@@ -90,7 +90,7 @@ class FTS_Facebook_Options_Page {
 								<?php
 								echo sprintf(
 									esc_html( '%1$sLogin and get my Access Token%2$s', 'feed-them-social' ),
-									'<a href="' . esc_url( 'https://www.facebook.com/dialog/oauth?client_id=1123168491105924&redirect_uri=https://www.slickremix.com/facebook-token/&state=' . admin_url( 'admin.php?page=fts-facebook-feed-styles-submenu-page' ) . '&scope=pages_show_list' ) . '" class="fts-facebook-get-access-token">',
+									'<a href="' . esc_url( 'https://www.facebook.com/dialog/oauth?client_id=1123168491105924&redirect_uri=https://www.slickremix.com/facebook-token/&state=' . admin_url( 'admin.php?page=fts-facebook-feed-styles-submenu-page' ) . '&scope=pages_show_list,pages_read_engagement' ) . '" class="fts-facebook-get-access-token">',
 									'</a>'
 								);
 								?>
@@ -222,7 +222,7 @@ class FTS_Facebook_Options_Page {
 									<?php
 									echo sprintf(
 										esc_html( '%1$sLogin and get my Reviews Access Token%2$s', 'feed-them-social' ),
-										'<a href="' . esc_url( 'https://www.facebook.com/dialog/oauth?client_id=1123168491105924&redirect_uri=https://www.slickremix.com/facebook-token/&state=' . admin_url( 'admin.php?page=fts-facebook-feed-styles-submenu-page' ) . '%26reviews_token=yes&scope=pages_show_list' ) . '" class="fts-facebook-get-access-token">',
+										'<a href="' . esc_url( 'https://www.facebook.com/dialog/oauth?client_id=1123168491105924&redirect_uri=https://www.slickremix.com/facebook-token/&state=' . admin_url( 'admin.php?page=fts-facebook-feed-styles-submenu-page' ) . '%26reviews_token=yes&scope=pages_show_list,pages_read_engagement' ) . '" class="fts-facebook-get-access-token">',
 										'</a>'
 									);
 									?>

--- a/admin/class-fts-instagram-options-page.php
+++ b/admin/class-fts-instagram-options-page.php
@@ -228,7 +228,7 @@ class FTS_Instagram_Options_Page {
 							// This redirect url must have an &state= instead of a ?state= otherwise it will not work proper with the fb app. https://www.slickremix.com/instagram-token/&state=.
 							echo sprintf(
 								esc_html( '%1$sLogin and get my Access Token%2$s', 'feed-them-social' ),
-								'<a href="' . esc_url( 'https://www.facebook.com/dialog/oauth?client_id=1123168491105924&redirect_uri=https://www.slickremix.com/instagram-token/&state=' . admin_url( 'admin.php?page=fts-instagram-feed-styles-submenu-page' ) . '&scope=pages_show_list,instagram_basic' ) . '" class="fts-facebook-get-access-token">',
+								'<a href="' . esc_url( 'https://www.facebook.com/dialog/oauth?client_id=1123168491105924&redirect_uri=https://www.slickremix.com/instagram-token/&state=' . admin_url( 'admin.php?page=fts-instagram-feed-styles-submenu-page' ) . '&scope=pages_show_list,pages_read_engagement,instagram_basic' ) . '" class="fts-facebook-get-access-token">',
 								'</a>'
 							);
 							?>

--- a/feed-them.php
+++ b/feed-them.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social - for Twitter feed, Youtube, Pinterest and more
  * Plugin URI: https://feedthemsocial.com/
  * Description: Display a Custom Facebook feed, Instagram feed, Twitter feed, Pinterest feed & YouTube feed on pages, posts or widgets.
- * Version: 2.8.8
+ * Version: 2.8.9
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 4.0.0
  * Tested up to: WordPress 5.5.1
- * Stable tag: 2.8.8
+ * Stable tag: 2.8.9
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    2.8.8
+ * @version    2.8.9
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2020 SlickRemix
  *
@@ -31,7 +31,7 @@
  *
  * Makes sure any js or css changes are reloaded properly. Added to enqued css and js files throughout!
  */
-define( 'FTS_CURRENT_VERSION', '2.8.8' );
+define( 'FTS_CURRENT_VERSION', '2.8.9' );
 
 define( 'FEED_THEM_SOCIAL_NOTICE_STATUS', get_option( 'rating_fts_slick_notice', false ) );
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: slickremix, slickchris
 Tags: Facebook, Instagram, Twitter, YouTube, Feed
 Requires at least: 3.6.0
 Tested up to: 5.5.1
-Stable tag: 2.8.8
+Stable tag: 2.8.9
 License: GPLv2 or later
 
 Display a Custom Facebook feed, Instagram feed, Twitter feed, Pinterest feed & YouTube feed on pages, posts or widgets.
@@ -75,6 +75,9 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
   * Log into WordPress dashboard then click **Plugins** > **Add new** > Then under the title "Install Plugins" click **Upload** > **choose the zip** > **Activate the plugin!**
 
 == Changelog ==
+Version 2.8.9 Friday, September 18th, 2020 =
+ * FIX: FACEBOOK & INSTAGRAM OPTIONS PAGE: missing pages_read_engagement scope so non admins of our APP can gain access to pages they manage.
+
 = Version 2.8.8 Thursday, September 17th, 2020 =
   * TESTED: Tested plugin with WordPress version 5.5.1.
   * FIX: Use WP_PLUGIN_DIR instead of WP_CONTENT_DIR to prevent fatal errors. Thanks to [stodorovic](https://github.com/stodorovic) for making the Pull Request on github.


### PR DESCRIPTION
Version 2.8.9 Friday, September 18th, 2020 =
 * FIX: FACEBOOK & INSTAGRAM OPTIONS PAGE: missing pages_read_engagement scope so non admins of our APP can gain access to pages they manage.