### PR TITLE
2.9.1

### DIFF
--- a/feed-them.php
+++ b/feed-them.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social - for Twitter feed, Youtube, Pinterest and more
  * Plugin URI: https://feedthemsocial.com/
  * Description: Display a Custom Facebook feed, Instagram feed, Twitter feed, Pinterest feed & YouTube feed on pages, posts or widgets.
- * Version: 2.9.0
+ * Version: 2.9.1
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 4.0.0
- * Tested up to: WordPress 5.5.2
- * Stable tag: 2.9.0
+ * Tested up to: WordPress 5.6.0
+ * Stable tag: 2.9.1
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    2.9.0
+ * @version    2.9.1
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2020 SlickRemix
  *
@@ -31,7 +31,7 @@
  *
  * Makes sure any js or css changes are reloaded properly. Added to enqued css and js files throughout!
  */
-define( 'FTS_CURRENT_VERSION', '2.9.0' );
+define( 'FTS_CURRENT_VERSION', '2.9.1' );
 
 define( 'FEED_THEM_SOCIAL_NOTICE_STATUS', get_option( 'rating_fts_slick_notice', false ) );
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: slickremix, slickchris
 Tags: Facebook, Instagram, Twitter, YouTube, Feed
 Requires at least: 3.6.0
-Tested up to: 5.5.2
-Stable tag: 2.9.0
+Tested up to: 5.6.0
+Stable tag: 2.9.1
 License: GPLv2 or later
 
 Display a Custom Facebook feed, Instagram feed, Twitter feed, Pinterest feed & YouTube feed on pages, posts or widgets.
@@ -75,13 +75,17 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
   * Log into WordPress dashboard then click **Plugins** > **Add new** > Then under the title "Install Plugins" click **Upload** > **choose the zip** > **Activate the plugin!**
 
 == Changelog ==
+Version 2.9.1 Wednesday, December 9th, 2020 =
+  * NOTE: Pinterest Feed: We will be removing this feed and options page on our next update temporarily until they get the API complete.
+  * TESTED: Tested plugin with WordPress version 5.6.0.
+
 Version 2.9.0 Thursday, October 29th, 2020 =
- * FIX: INSTAGRAM FEED: Missing images for videos.
- * PREMIUM FIX: INSTAGRAM FEED: Pop for images.
- * PREMIUM FIX COMING: INSTAGRAM HASHTAG FEED: Images for Videos are missing.
+  * FIX: INSTAGRAM FEED: Missing images for videos.
+  * PREMIUM FIX: INSTAGRAM FEED: Pop for images.
+  * PREMIUM FIX COMING: INSTAGRAM HASHTAG FEED: Images for Videos are missing.
 
 Version 2.8.9 Friday, September 18th, 2020 =
- * FIX: FACEBOOK & INSTAGRAM OPTIONS PAGE: missing pages_read_engagement scope so non admins of our APP can gain access to pages they manage.
+  * FIX: FACEBOOK & INSTAGRAM OPTIONS PAGE: missing pages_read_engagement scope so non admins of our APP can gain access to pages they manage.
 
 = Version 2.8.8 Thursday, September 17th, 2020 =
   * TESTED: Tested plugin with WordPress version 5.5.1.


### PR DESCRIPTION
Version 2.9.1 Wednesday, December 9th, 2020 =
  * NOTE: Pinterest Feed: We will be removing this feed and options page on our next update temporarily until they get the API complete.
  * TESTED: Tested plugin with WordPress version 5.6.0.