### PR TITLE
2.9.2

### DIFF
--- a/admin/class-fts-facebook-options-page.php
+++ b/admin/class-fts-facebook-options-page.php
@@ -89,7 +89,7 @@ class FTS_Facebook_Options_Page {
 							<p>
 								<?php
 								echo sprintf(
-									esc_html( '%1$sLogin and get my Access Token%2$s', 'feed-them-social' ),
+									esc_html__( '%1$sLogin and get my Access Token%2$s', 'feed-them-social' ),
 									'<a href="' . esc_url( 'https://www.facebook.com/dialog/oauth?client_id=1123168491105924&redirect_uri=https://www.slickremix.com/facebook-token/&state=' . admin_url( 'admin.php?page=fts-facebook-feed-styles-submenu-page' ) . '&scope=pages_show_list,pages_read_engagement' ) . '" class="fts-facebook-get-access-token">',
 									'</a>'
 								);
@@ -150,7 +150,7 @@ class FTS_Facebook_Options_Page {
 									}
 
 									echo sprintf(
-										esc_html( 'Your Access Token is now working! Generate your shortcode on the %1$sSettings Page%2$s', 'feed-them-social' ),
+										esc_html__( 'Your Access Token is now working! Generate your shortcode on the %1$sSettings Page%2$s', 'feed-them-social' ),
 										'<a href="' . esc_url( 'admin.php?page=feed-them-settings-page#feed_type=facebook' ) . '">',
 										'</a>'
 									);
@@ -160,7 +160,7 @@ class FTS_Facebook_Options_Page {
 								if ( isset( $test_app_token_response->data->error->message ) && ! empty( $test_app_token_id ) || isset( $test_app_token_response->error->message ) && ! empty( $test_app_token_id ) && '(#100) You must provide an app access token or a user access token that is an owner or developer of the app' !== $test_app_token_response->error->message ) {
 									if ( isset( $test_app_token_response->data->error->message ) ) {
 										echo sprintf(
-											esc_html( '%1$sOh No something\'s wrong. %2$s. Please click the button above to retrieve a new Access Token.%3$s', 'feed-them-social' ),
+											esc_html__( '%1$sOh No something\'s wrong. %2$s. Please click the button above to retrieve a new Access Token.%3$s', 'feed-them-social' ),
 											'<div class="fts-failed-api-token">',
 											esc_html( $test_app_token_response->data->error->message ),
 											'</div>'
@@ -168,7 +168,7 @@ class FTS_Facebook_Options_Page {
 									}
 									if ( isset( $test_app_token_response->error->message ) ) {
 										echo sprintf(
-											esc_html( '%1$sOh No something\'s wrong. %2$s. Please click the button above to retrieve a new Access Token.%3$s', 'feed-them-social' ),
+											esc_html__( '%1$sOh No something\'s wrong. %2$s. Please click the button above to retrieve a new Access Token.%3$s', 'feed-them-social' ),
 											'<div class="fts-failed-api-token">',
 											esc_html( $test_app_token_response->error->message ),
 											'</div>'
@@ -177,7 +177,7 @@ class FTS_Facebook_Options_Page {
 
 									if ( isset( $test_app_token_response->data->error->message ) && empty( $test_app_token_id ) || isset( $test_app_token_response->error->message ) && empty( $test_app_token_id ) ) {
 										echo sprintf(
-											esc_html( '%1$sTo get started, please click the button above to retrieve your Access Token.%2$s', 'feed-them-social' ),
+											esc_html__( '%1$sTo get started, please click the button above to retrieve your Access Token.%2$s', 'feed-them-social' ),
 											'<div class="fts-failed-api-token get-started-message">',
 											'</div>'
 										);
@@ -186,7 +186,7 @@ class FTS_Facebook_Options_Page {
 							} else {
 								if ( ! isset( $_GET['return_long_lived_token'] ) || isset( $_GET['reviews_token'] ) ) {
 									echo sprintf(
-										esc_html( '%1$sTo get started, please click the button above to retrieve your Access Token.%2$s', 'feed-them-social' ),
+										esc_html__( '%1$sTo get started, please click the button above to retrieve your Access Token.%2$s', 'feed-them-social' ),
 										'<div class="fts-failed-api-token get-started-message">',
 										'</div>'
 									);
@@ -221,7 +221,7 @@ class FTS_Facebook_Options_Page {
 								<p>
 									<?php
 									echo sprintf(
-										esc_html( '%1$sLogin and get my Reviews Access Token%2$s', 'feed-them-social' ),
+										esc_html__( '%1$sLogin and get my Reviews Access Token%2$s', 'feed-them-social' ),
 										'<a href="' . esc_url( 'https://www.facebook.com/dialog/oauth?client_id=1123168491105924&redirect_uri=https://www.slickremix.com/facebook-token/&state=' . admin_url( 'admin.php?page=fts-facebook-feed-styles-submenu-page' ) . '%26reviews_token=yes&scope=pages_show_list,pages_read_engagement' ) . '" class="fts-facebook-get-access-token">',
 										'</a>'
 									);
@@ -297,7 +297,7 @@ class FTS_Facebook_Options_Page {
 							<div class="feed-them-social-admin-input-label fb-events-title-color-label">
 								<?php
 								echo sprintf(
-									esc_html( 'Stars Background Color%1$sApplies to Overall Rating too.%2$s', 'feed-them-social' ),
+									esc_html__( 'Stars Background Color%1$sApplies to Overall Rating too.%2$s', 'feed-them-social' ),
 									'<br/><small>',
 									'</small>'
 								);
@@ -312,7 +312,7 @@ class FTS_Facebook_Options_Page {
 							<div class="feed-them-social-admin-input-label fb-events-map-link-color-label">
 								<?php
 								echo sprintf(
-									esc_html( 'Stars & Text Color%1$sApplies to Overall Rating too.%2$s', 'feed-them-social' ),
+									esc_html__( 'Stars & Text Color%1$sApplies to Overall Rating too.%2$s', 'feed-them-social' ),
 									'<br/><small>',
 									'</small>'
 								);
@@ -460,7 +460,7 @@ class FTS_Facebook_Options_Page {
 							<?php
 
 							echo sprintf(
-								esc_html( 'You must have your Facebook Access Token saved above before this feature will work. This option will translate the FB Titles and Like Button or Box Text. It will not translate your actual post. To translate the Feed Them Social parts of this plugin just set your language on the %1$sWordPress settings%2$s page. If would like to help translate please %3$sClick Here.%4$s', 'feed-them-social' ),
+								esc_html__( 'You must have your Facebook Access Token saved above before this feature will work. This option will translate the FB Titles and Like Button or Box Text. It will not translate your actual post. To translate the Feed Them Social parts of this plugin just set your language on the %1$sWordPress settings%2$s page. If would like to help translate please %3$sClick Here.%4$s', 'feed-them-social' ),
 								'<a href="' . esc_url( 'options-general.php' ) . '" target="_blank">',
 								'</a>',
 								'<a href="' . esc_url( 'http://translate.slickremix.com/glotpress/projects/feed-them-social/' ) . '" target="_blank">',
@@ -496,7 +496,7 @@ class FTS_Facebook_Options_Page {
 							</h3>
 							<?php
 							echo sprintf(
-								esc_html( '%1$sWARNING, PLEASE READ CAREFULLY!%2$s DO NOT use this field to set your facebook posts. If you are getting the message "Please go to the Facebook Options page of our plugin and look for the "Change Limit" option and add the number 7 or more." then adjust the number below so posts will show in your feed. Generally adding at least %3$s7%4$s is a good idea if you are getting that notice. This is only for Pages and Groups. We filter certain posts that do not have a story or message or if the shared content is not available via the API.', 'feed-them-social' ),
+								esc_html__( '%1$sWARNING, PLEASE READ CAREFULLY!%2$s DO NOT use this field to set your facebook posts. If you are getting the message "Please go to the Facebook Options page of our plugin and look for the "Change Limit" option and add the number 7 or more." then adjust the number below so posts will show in your feed. Generally adding at least %3$s7%4$s is a good idea if you are getting that notice. This is only for Pages and Groups. We filter certain posts that do not have a story or message or if the shared content is not available via the API.', 'feed-them-social' ),
 								'<strong style="color:red">',
 								'</strong>',
 								'<strong>',
@@ -663,7 +663,7 @@ class FTS_Facebook_Options_Page {
 						<div class="feed-them-social-admin-input-label fts-twitter-text-color-label">
 							<?php
 							echo sprintf(
-								esc_html( 'Page Title Tag %1$s %2$s', 'feed-them-social' ),
+								esc_html__( 'Page Title Tag %1$s %2$s', 'feed-them-social' ),
 								'<br/><small>',
 								'</small>'
 							);

--- a/admin/class-fts-instagram-options-page.php
+++ b/admin/class-fts-instagram-options-page.php
@@ -42,11 +42,11 @@ class FTS_Instagram_Options_Page {
         $fts_instagram_custom_id             = get_option( 'fts_instagram_custom_id' );
         $fts_instagram_show_follow_btn       = get_option( 'instagram_show_follow_btn' );
         $fts_instagram_show_follow_btn_where = get_option( 'instagram_show_follow_btn_where' );
-        $user_id_basic                       = isset( $_GET['access_token'], $_GET['feed_type']  ) && 'instagram_basic' === $_GET['feed_type'] ? sanitize_text_field( $_GET['user_id'] ) : $fts_instagram_custom_id;
-        $access_token_basic                  = isset( $_GET['access_token'], $_GET['feed_type']  ) && 'instagram_basic' === $_GET['feed_type'] ? sanitize_text_field( $_GET['access_token'] ) : get_option( 'fts_instagram_custom_api_token' );
-        $access_token                        = isset( $_GET['access_token'], $_GET['feed_type'] ) && 'original_instagram' === $_GET['feed_type'] ? sanitize_text_field( $_GET['access_token'] ) : $access_token_basic;
+        $user_id_basic                       = isset( $_GET['code'], $_GET['feed_type']  ) && 'instagram_basic' === $_GET['feed_type'] ? sanitize_text_field( $_GET['user_id'] ) : $fts_instagram_custom_id;
+        $access_token_basic                  = isset( $_GET['code'], $_GET['feed_type']  ) && 'instagram_basic' === $_GET['feed_type'] ? sanitize_text_field( $_GET['code'] ) : get_option( 'fts_instagram_custom_api_token' );
+        $access_token                        = isset( $_GET['code'], $_GET['feed_type'] ) && 'original_instagram' === $_GET['feed_type'] ? sanitize_text_field( $_GET['code'] ) : $access_token_basic;
 
-        if ( isset( $_GET['access_token'] ) ) { ?>
+        if ( isset( $_GET['code'] ) ) { ?>
             <script>
                 jQuery(document).ready(function ($) {
 
@@ -109,14 +109,14 @@ class FTS_Instagram_Options_Page {
                         ?>
                         <p>
                             <?php
-                            echo esc_html( 'This is required to make the Instagram Feed work. Click the button below and it will connect to your Instagram Account to get an access token. It will then return to this page and save it in the inputs below. After it finishes you will be able to generate your Instagram feed. Instagram Basic connections do not allow you to show Profile info or Heart/Comment counts. Please use the Instagram Business option to achieve that.', 'feed-them-social' );
+                            echo esc_html__( 'This is required to make the Instagram Feed work. Click the button below and it will connect to your Instagram Account to get an access token. It will then return to this page and save it in the inputs below. After it finishes you will be able to generate your Instagram feed. Instagram Basic connections do not allow you to show Profile info or Heart/Comment counts. Please use the Instagram Business option to achieve that.', 'feed-them-social' );
                             ?>
                         </p>
                         <p>
                             <?php
 
                             echo sprintf(
-                                esc_html( '%1$sLogin and get my Access Token%2$s', 'feed-them-social' ),
+                                esc_html__( '%1$sLogin and get my Access Token%2$s', 'feed-them-social' ),
                                 '<a href="' . esc_url( 'https://api.instagram.com/oauth/authorize?app_id=206360940619297&redirect_uri=https://www.slickremix.com/instagram-basic-token/&response_type=code&scope=user_profile,user_media&state=' . admin_url( 'admin.php?page=fts-instagram-feed-styles-submenu-page' ) . '' ) . '" class="fts-instagram-get-access-token">',
                                 '</a>'
                             );
@@ -140,7 +140,7 @@ class FTS_Instagram_Options_Page {
                             <?php
                             esc_html_e( 'Access Token Required', 'feed-them-social' );
 
-                            if ( isset( $_GET['access_token'], $_GET['feed_type'] ) && 'original_instagram' === $_GET['feed_type'] || isset( $_GET['access_token'], $_GET['feed_type'] ) && 'instagram_basic' === $_GET['feed_type'] ) {
+                            if ( isset( $_GET['code'], $_GET['feed_type'] ) && 'original_instagram' === $_GET['feed_type'] || isset( $_GET['code'], $_GET['feed_type'] ) && 'instagram_basic' === $_GET['feed_type'] ) {
                                 // START AJAX TO SAVE TOKEN TO DB
                                 $fts_functions->feed_them_instagram_save_token();
                             }
@@ -165,7 +165,7 @@ class FTS_Instagram_Options_Page {
 
                         if( ! empty( $fts_instagram_access_token ) && 0 !== $count ){
                             echo sprintf(
-                                esc_html( '%1$sThe %2$sLegacy API will be depreciated as of March 31st, 2020%3$s in favor of the new Instagram Graph API and the Instagram Basic Display API. Please click the the button above to reconnect your account or you can connect as a Business account below. You must also generate a new shortcode and replace your existing one.%4$s', 'feed-them-social' ),
+                                esc_html__( '%1$sThe %2$sLegacy API will be depreciated as of March 31st, 2020%3$s in favor of the new Instagram Graph API and the Instagram Basic Display API. Please click the the button above to reconnect your account or you can connect as a Business account below. You must also generate a new shortcode and replace your existing one.%4$s', 'feed-them-social' ),
                                 '<div class="fts-failed-api-token instagram-failed-message">',
                                 '<a href="' . esc_url( 'https://www.instagram.com/developer/' ) . '" target="_blank">',
                                 '</a>',
@@ -174,7 +174,7 @@ class FTS_Instagram_Options_Page {
                         }
                         elseif ( ! isset( $test_app_token_response->error ) && ! empty( $fts_instagram_access_token ) ) {
                             echo sprintf(
-                                esc_html( '%1$sYour access token is working! Generate your shortcode on the %2$sSettings Page%3$s', 'feed-them-social' ),
+                                esc_html__( '%1$sYour access token is working! Generate your shortcode on the %2$sSettings Page%3$s', 'feed-them-social' ),
                                 '<div class="fts-successful-api-token">',
                                 '<a href="' . esc_url( 'admin.php?page=feed-them-settings-page' . $custom_instagram_link_hash ) . '">',
                                 '</a></div>'
@@ -182,7 +182,7 @@ class FTS_Instagram_Options_Page {
                         } elseif ( isset( $test_app_token_response->error ) && ! empty( $fts_instagram_access_token ) ) {
                             $text = isset( $test_app_token_response->error->message ) ? $test_app_token_response->error->message : $test_app_token_response->error->message;
                             echo sprintf(
-                                esc_html( '%1$sOh No something\'s wrong. %2$s Please try clicking the button again to get a new access token. If you need additional assistance please email us at support@slickremix.com %3$s', 'feed-them-social' ),
+                                esc_html__( '%1$sOh No something\'s wrong. %2$s Please try clicking the button again to get a new access token. If you need additional assistance please email us at support@slickremix.com %3$s', 'feed-them-social' ),
                                 '<div class="fts-failed-api-token instagram-failed-message">',
                                 esc_html( $text ),
                                 '</div>'
@@ -193,7 +193,7 @@ class FTS_Instagram_Options_Page {
 
                         if ( empty( $fts_instagram_access_token ) && 'original_instagram' !== $feed_type ) {
                             echo sprintf(
-                                esc_html( '%1$sYou are required to get an access token to view your photos.%2$s', 'feed-them-social' ),
+                                esc_html__( '%1$sYou are required to get an access token to view your photos.%2$s', 'feed-them-social' ),
                                 '<div class="fts-failed-api-token instagram-failed-message">',
                                 '</div>'
                             );
@@ -214,7 +214,7 @@ class FTS_Instagram_Options_Page {
                         </h3>
                         <?php
                         echo sprintf(
-                            esc_html( 'You must have your Instagram Account linked to a Facebook Business Page, this is required to make the Instagram Business Feed or Hashtag Feed work. %1$sRead Instructions%2$s. Once you have completed the instructions you can click the button below and it will connect to your Facebook Account to get an access token. It should return a Facebook page or list of pages you are admin of and display which ones are connected to Instagram. Choose one, then click save. The Instagram Business option will allow you to display your profile info and the Heart/Comment counts on your media.', 'feed-them-social' ),
+                            esc_html__( 'You must have your Instagram Account linked to a Facebook Business Page, this is required to make the Instagram Business Feed or Hashtag Feed work. %1$sRead Instructions%2$s. Once you have completed the instructions you can click the button below and it will connect to your Facebook Account to get an access token. It should return a Facebook page or list of pages you are admin of and display which ones are connected to Instagram. Choose one, then click save. The Instagram Business option will allow you to display your profile info and the Heart/Comment counts on your media.', 'feed-them-social' ),
                             '<a target="_blank" href="' . esc_url( 'https://www.slickremix.com/docs/link-instagram-account-to-facebook/' ) . '">',
                             '</a>'
                         );
@@ -227,7 +227,7 @@ class FTS_Instagram_Options_Page {
                             // 1844222799032692?fields=instagram_business_account&access_token=
                             // This redirect url must have an &state= instead of a ?state= otherwise it will not work proper with the fb app. https://www.slickremix.com/instagram-token/&state=.
                             echo sprintf(
-                                esc_html( '%1$sLogin and get my Access Token%2$s', 'feed-them-social' ),
+                                esc_html__( '%1$sLogin and get my Access Token%2$s', 'feed-them-social' ),
                                 '<a href="' . esc_url( 'https://www.facebook.com/dialog/oauth?client_id=1123168491105924&redirect_uri=https://www.slickremix.com/instagram-token/&state=' . admin_url( 'admin.php?page=fts-instagram-feed-styles-submenu-page' ) . '&scope=pages_show_list,pages_read_engagement,instagram_basic' ) . '" class="fts-facebook-get-access-token">',
                                 '</a>'
                             );
@@ -291,7 +291,7 @@ class FTS_Instagram_Options_Page {
                                 }
 
                                 echo sprintf(
-                                    esc_html( 'Your access token is working! Generate your shortcode on the %1$sSettings Page%2$s', 'feed-them-social' ),
+                                    esc_html__( 'Your access token is working! Generate your shortcode on the %1$sSettings Page%2$s', 'feed-them-social' ),
                                     '<a href="' . esc_url( 'admin.php?page=feed-them-settings-page' . $custom_instagram_link_hash ) . '">',
                                     '</a>'
                                 );
@@ -301,7 +301,7 @@ class FTS_Instagram_Options_Page {
                             if ( isset( $test_app_token_response->data->error->message ) && ! empty( $test_app_token_id ) || isset( $test_app_token_response->error->message ) && ! empty( $test_app_token_id ) && '(#100) You must provide an app access token or a user access token that is an owner or developer of the app' !== $test_app_token_response->error->message ) {
                                 if ( isset( $test_app_token_response->data->error->message ) ) {
                                     echo sprintf(
-                                        esc_html( '%1$sOh No something\'s wrong. %2$s. Please click the button above to retrieve a new Access Token.%3$s', 'feed-them-social' ),
+                                        esc_html__( '%1$sOh No something\'s wrong. %2$s. Please click the button above to retrieve a new Access Token.%3$s', 'feed-them-social' ),
                                         '<div class="fts-failed-api-token">',
                                         esc_html( $test_app_token_response->data->error->message ),
                                         '</div>'
@@ -309,7 +309,7 @@ class FTS_Instagram_Options_Page {
                                 }
                                 if ( isset( $test_app_token_response->error->message ) ) {
                                     echo sprintf(
-                                        esc_html( '%1$sOh No something\'s wrong. %2$s. Please click the button above to retrieve a new Access Token.%3$s', 'feed-them-social' ),
+                                        esc_html__( '%1$sOh No something\'s wrong. %2$s. Please click the button above to retrieve a new Access Token.%3$s', 'feed-them-social' ),
                                         '<div class="fts-failed-api-token">',
                                         esc_html( $test_app_token_response->error->message ),
                                         '</div>'
@@ -318,7 +318,7 @@ class FTS_Instagram_Options_Page {
 
                                 if ( isset( $test_app_token_response->data->error->message ) && empty( $test_app_token_id ) || isset( $test_app_token_response->error->message ) && empty( $test_app_token_id ) ) {
                                     echo sprintf(
-                                        esc_html( '%1$sTo get started, please click the button above to retrieve your Access Token.%2$s', 'feed-them-social' ),
+                                        esc_html__( '%1$sTo get started, please click the button above to retrieve your Access Token.%2$s', 'feed-them-social' ),
                                         '<div class="fts-failed-api-token get-started-message">',
                                         '</div>'
                                     );
@@ -327,7 +327,7 @@ class FTS_Instagram_Options_Page {
                         } else {
                             if ( ! isset( $_GET['return_long_lived_token'] ) || isset( $_GET['reviews_token'] ) ) {
                                 echo sprintf(
-                                    esc_html( '%1$sTo get started, please click the button above to retrieve your Access Token.%2$s', 'feed-them-social' ),
+                                    esc_html__( '%1$sTo get started, please click the button above to retrieve your Access Token.%2$s', 'feed-them-social' ),
                                     '<div class="fts-failed-api-token get-started-message">',
                                     '</div>'
                                 );

--- a/admin/class-fts-pinterest-options-page.php
+++ b/admin/class-fts-pinterest-options-page.php
@@ -39,17 +39,17 @@ class FTS_Pinterest_Options_Page {
 		?>
         <div class="fts-failed-api-token" style="margin-bottom: 20px;">
             <?php
-            echo esc_html( 'Without notice or warning the Pinterest API has become unavailable. Once the API is available to us again we will make an update to correct the issue. For the time being we are going to disable the access token button. 4-20-2020', 'feed-them-social' );
+            echo esc_html__( 'Without notice or warning the Pinterest API has become unavailable. Once the API is available to us again we will make an update to correct the issue. For the time being we are going to disable the access token button. 4-20-2020', 'feed-them-social' );
             ?>
         </div>
 
         <div class="feed-them-social-admin-wrap">
 
 			<h1>
-				<?php echo esc_html( 'Pinterest Feed Options', 'feed-them-social' ); ?>
+				<?php echo esc_html__( 'Pinterest Feed Options', 'feed-them-social' ); ?>
 			</h1>
 			<div class="use-of-plugin">
-				<?php echo esc_html( 'Add a follow button and position it using the options below.', 'feed-them-social' ); ?>
+				<?php echo esc_html__( 'Add a follow button and position it using the options below.', 'feed-them-social' ); ?>
 			</div>
 
 			<!-- custom option for padding -->
@@ -66,28 +66,28 @@ class FTS_Pinterest_Options_Page {
 				<div class="feed-them-social-admin-input-wrap" style="padding-top:0; display: noneee">
 					<div class="fts-title-description-settings-page">
 						<h3>
-							<?php echo esc_html( 'Pinterest Access Token', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Pinterest Access Token', 'feed-them-social' ); ?>
 						</h3>
 
-						<p><?php echo esc_html( 'This is required to make the feed work. Click the button below and it will connect to your Pinterest account to get an access token, and it will return it in the input below. Then click the save button and you will now be able to generate your Pinterest feed from the Settings page of our plugin.', 'feed-them-social' ); ?>
+						<p><?php echo esc_html__( 'This is required to make the feed work. Click the button below and it will connect to your Pinterest account to get an access token, and it will return it in the input below. Then click the save button and you will now be able to generate your Pinterest feed from the Settings page of our plugin.', 'feed-them-social' ); ?>
 						</p>
 						<p>
 							<?php
 							echo sprintf(
-								esc_html( '%1$sLogin and get my Access Token%2$s', 'feed-them-social' ),
+								esc_html__( '%1$sLogin and get my Access Token%2$s', 'feed-them-social' ),
 								'<a href="' . esc_url( 'https://api.pinterest.com/oauth/?response_type=token&redirect_uri=https://www.slickremix.com/pinterest-token-plugin/&client_id=5063534389122615467&scope=read_public&state=' . admin_url( 'admin.php?page=fts-pinterest-feed-styles-submenu-page' ) ) . '" class="fts-pinterest-get-access-token">',
 								'</a>'
 							);
 							?>
 						</p>
-						<a href="<?php echo esc_url( 'mailto:support@slickremix.com' ); ?>" style="margin-top:14px;display:inline-block" class="fts-admin-button-no-work"><?php echo esc_html( 'Button not working?', 'feed-them-social' ); ?></a>
+						<a href="<?php echo esc_url( 'mailto:support@slickremix.com' ); ?>" style="margin-top:14px;display:inline-block" class="fts-admin-button-no-work"><?php echo esc_html__( 'Button not working?', 'feed-them-social' ); ?></a>
 					</div>
 
 					<div class="fts-clear"></div>
 
 					<div class="feed-them-social-admin-input-wrap" style="margin-bottom:0;">
 						<div class="feed-them-social-admin-input-label fts-twitter-border-bottom-color-label">
-							<?php echo esc_html( 'Access Token Required', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Access Token Required', 'feed-them-social' ); ?>
 						</div>
 
 						<input type="text" name="fts_pinterest_custom_api_token" class="feed-them-social-admin-input" id="fts_pinterest_custom_api_token" value="<?php echo esc_attr( $access_token ); ?>"/>
@@ -103,14 +103,14 @@ class FTS_Pinterest_Options_Page {
 					// Error Check!
 					if ( ! isset( $test_app_token_response->status ) && ! empty( $fts_pinterest_access_token ) ) {
 						echo sprintf(
-							esc_html( '%1$sYour access token is working! Generate your shortcode on the %2$sSettings Page%3$s', 'feed-them-social' ),
+							esc_html__( '%1$sYour access token is working! Generate your shortcode on the %2$sSettings Page%3$s', 'feed-them-social' ),
 							'<div class="fts-successful-api-token">',
 							'<a href="' . esc_url( 'admin.php?page=feed-them-settings-page' ) . '">',
 							'</a></div>'
 						);
 					} elseif ( isset( $test_app_token_response->status ) && ! empty( $fts_pinterest_access_token ) ) {
 						echo sprintf(
-							esc_html( '%1$sOh No something\'s wrong. %2$s. Please try again, if you are still having troulbes please contact us on our Support Forum. Make sure to include screenshots of the browser page that may come up with any errors. %3$sSupport Forum%4$s', 'feed-them-social' ),
+							esc_html__( '%1$sOh No something\'s wrong. %2$s. Please try again, if you are still having troulbes please contact us on our Support Forum. Make sure to include screenshots of the browser page that may come up with any errors. %3$sSupport Forum%4$s', 'feed-them-social' ),
 							'<div class="fts-failed-api-token">',
 							esc_html( $test_app_token_response->message ),
 							'<a href="' . esc_url( 'https://www.slickremix.com/support/' ) . '">',
@@ -119,7 +119,7 @@ class FTS_Pinterest_Options_Page {
 					}
 					if ( empty( $fts_pinterest_access_token ) ) {
 						echo sprintf(
-							esc_html( '%1$sYou are required to get an access token to view your any of the Pinterest Feeds. Click "Save All Changes" after getting your Access Token.%2$s', 'feed-them-social' ),
+							esc_html__( '%1$sYou are required to get an access token to view your any of the Pinterest Feeds. Click "Save All Changes" after getting your Access Token.%2$s', 'feed-them-social' ),
 							'<div class="fts-failed-api-token">',
 							'</div>'
 						);
@@ -133,18 +133,18 @@ class FTS_Pinterest_Options_Page {
 				<div class="feed-them-social-admin-input-wrap">
 					<div class="fts-title-description-settings-page">
 						<h3>
-							<?php echo esc_html( 'Follow Button Options', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Follow Button Options', 'feed-them-social' ); ?>
 						</h3>
-						<?php echo esc_html( 'This will only show on regular feeds not combined feeds.', 'feed-them-social' ); ?>
+						<?php echo esc_html__( 'This will only show on regular feeds not combined feeds.', 'feed-them-social' ); ?>
 					</div>
-					<div class="feed-them-social-admin-input-label fts-twitter-text-color-label"><?php echo esc_html( 'Show Follow Button', 'feed-them-social' ); ?></div>
+					<div class="feed-them-social-admin-input-label fts-twitter-text-color-label"><?php echo esc_html__( 'Show Follow Button', 'feed-them-social' ); ?></div>
 
 					<select name="pinterest_show_follow_btn" id="pinterest-show-follow-btn" class="feed-them-social-admin-input">
 						<option <?php echo selected( $fts_pinterest_show_follow_btn, 'no', false ); ?> value="<?php echo esc_attr( 'no' ); ?>">
-							<?php echo esc_html( 'No', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'No', 'feed-them-social' ); ?>
 						</option>
 						<option <?php echo selected( $fts_pinterest_show_follow_btn, 'yes', false ); ?> value="<?php echo esc_attr( 'yes' ); ?>">
-							<?php echo esc_html( 'Yes', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Yes', 'feed-them-social' ); ?>
 						</option>
 					</select>
 
@@ -152,17 +152,17 @@ class FTS_Pinterest_Options_Page {
 				</div><!--/fts-twitter-feed-styles-input-wrap-->
 
 				<div class="feed-them-social-admin-input-wrap">
-					<div class="feed-them-social-admin-input-label fts-twitter-text-color-label"><?php echo esc_html( 'Placement of the Buttons', 'feed-them-social' ); ?></div>
+					<div class="feed-them-social-admin-input-label fts-twitter-text-color-label"><?php echo esc_html__( 'Placement of the Buttons', 'feed-them-social' ); ?></div>
 
 					<select name="pinterest_show_follow_btn_where" id="pinterest-show-follow-btn-where" class="feed-them-social-admin-input">
 						<option>
-							<?php echo esc_html( 'Please Select Option', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Please Select Option', 'feed-them-social' ); ?>
 						</option>
 						<option <?php echo selected( $fts_pinterest_show_follow_btn_where, 'pinterest-follow-above', false ); ?> value="<?php echo esc_attr( 'pinterest-follow-above' ); ?>">
-							<?php echo esc_html( 'Show Above Feed', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Show Above Feed', 'feed-them-social' ); ?>
 						</option>
 						<option <?php echo selected( $fts_pinterest_show_follow_btn_where, 'pinterest-follow-below', false ); ?> value="<?php echo esc_attr( 'pinterest-follow-below' ); ?>">
-							<?php echo esc_html( 'Show Below Feed', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Show Below Feed', 'feed-them-social' ); ?>
 						</option>
 					</select>
 
@@ -172,18 +172,18 @@ class FTS_Pinterest_Options_Page {
 				<div class="feed-them-social-admin-input-wrap">
 					<div class="fts-title-description-settings-page">
 						<h3>
-							<?php echo esc_html( 'Boards List Style Options', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Boards List Style Options', 'feed-them-social' ); ?>
 						</h3>
 						<?php
 						echo sprintf(
-							esc_html( 'These styles are for the list of Boards type feed %1$sseen here%2$s', 'feed-them-social' ),
+							esc_html__( 'These styles are for the list of Boards type feed %1$sseen here%2$s', 'feed-them-social' ),
 							'<a href="' . esc_url( 'https://feedthemsocial.com/pinterest/' ) . '" target="_blank">',
 							'</a>'
 						);
 						?>
 					</div>
 					<div class="feed-them-social-admin-input-label fts-fb-text-color-label">
-						<?php echo esc_html( 'Board Title Color', 'feed-them-social' ); ?>
+						<?php echo esc_html__( 'Board Title Color', 'feed-them-social' ); ?>
 					</div>
 					<input type="text" name="pinterest_board_title_color" class="feed-them-social-admin-input fb-text-color-input color {hash:true,caps:false,required:false,adjust:false,pickerFaceColor:'#eee',pickerFace:3,pickerBorder:0,pickerInsetColor:'white'}" id="pinterest_board_title_color" placeholder="#555555" value="<?php echo esc_attr( get_option( 'pinterest_board_title_color' ) ); ?>"/>
 					<div class="fts-clear"></div>
@@ -191,7 +191,7 @@ class FTS_Pinterest_Options_Page {
 				<!--/fts-facebook-feed-styles-input-wrap-->
 				<div class="feed-them-social-admin-input-wrap">
 					<div class="feed-them-social-admin-input-label fts-fb-text-color-label">
-						<?php echo esc_html( 'Board Title Size', 'feed-them-social' ); ?>
+						<?php echo esc_html__( 'Board Title Size', 'feed-them-social' ); ?>
 					</div>
 					<input type="text" name="pinterest_board_title_size" class="feed-them-social-admin-input" placeholder="16px" value="<?php echo esc_attr( get_option( 'pinterest_board_title_size' ) ); ?>"/>
 					<div class="fts-clear"></div>
@@ -199,7 +199,7 @@ class FTS_Pinterest_Options_Page {
 				<!--/fts-facebook-feed-styles-input-wrap-->
 				<div class="feed-them-social-admin-input-wrap">
 					<div class="feed-them-social-admin-input-label fts-fb-link-color-label">
-						<?php echo esc_html( 'Background on Hover', 'feed-them-social' ); ?>
+						<?php echo esc_html__( 'Background on Hover', 'feed-them-social' ); ?>
 					</div>
 					<input type="text" name="pinterest_board_backg_hover_color" class="feed-them-social-admin-input fb-link-color-input color {hash:true,caps:false,required:false,adjust:false,pickerFaceColor:'#eee',pickerFace:3,pickerBorder:0,pickerInsetColor:'white'}" id="pinterest_board_backg_hover_color" placeholder="#FFF" value="<?php echo esc_attr( get_option( 'pinterest_board_backg_hover_color' ) ); ?>"/>
 					<div class="fts-clear"></div>
@@ -207,7 +207,7 @@ class FTS_Pinterest_Options_Page {
 				<!--/fts-facebook-feed-styles-input-wrap-->
 
 				<div class="fts-clear"></div>
-				<input type="submit" class="feed-them-social-admin-submit-btn" value="<?php echo esc_html( 'Save All Changes' ); ?>"/>
+				<input type="submit" class="feed-them-social-admin-submit-btn" value="<?php echo esc_html__( 'Save All Changes' ); ?>"/>
 			<?php } ?>
 			</form>
 		</div>

--- a/admin/class-fts-settings-page.php
+++ b/admin/class-fts-settings-page.php
@@ -41,7 +41,7 @@ class FTS_Settings_Page {
 		$fts_functions = new feed_them_social_functions();
 
 		if ( ! function_exists( 'curl_init' ) ) {
-			print '<div class="error"><p>' . esc_html( 'Warning: cURL is not installed on this server. It is required to use this plugin. Please contact your host provider to install this.', 'feed-them-social' ) . '</p></div>';
+			print '<div class="error"><p>' . esc_html__( 'Warning: cURL is not installed on this server. It is required to use this plugin. Please contact your host provider to install this.', 'feed-them-social' ) . '</p></div>';
 		}
 
 		$fts_fb_options_nonce = wp_create_nonce( 'fts-settings-page-nonce' );
@@ -52,7 +52,7 @@ class FTS_Settings_Page {
 			<div class="feed-them-social-admin-wrap">
 				<div class="fts-backg"></div>
 				<div class="fts-content">
-					<h1 class="fts-logo-header"><?php echo esc_html( 'Feed Them Social', 'feed-them-social' ); ?></h1>
+					<h1 class="fts-logo-header"><?php echo esc_html__( 'Feed Them Social', 'feed-them-social' ); ?></h1>
 
 					<div class="feed-them-icon-wrap">
 						<a href="javascript:" class="youtube-icon"></a>
@@ -62,35 +62,35 @@ class FTS_Settings_Page {
 						<a href="javascript:" class="pinterest-icon"></a>
 
 						<div id="discount-for-review">
-							<a href="admin.php?page=fts-license-page"><?php echo esc_html( 'View Extensions & Demos', 'feed-them-social' ); ?></a>
+							<a href="admin.php?page=fts-license-page"><?php echo esc_html__( 'View Extensions & Demos', 'feed-them-social' ); ?></a>
 						</div>
 					</div>
 
 					<div class="fts-tabs" id="fts-tabs">
 
 						<label for="fts-tab1" class="fts-tab1 fts-tabbed <?php echo isset( $_GET['tab'] ) && 'general_options' === $_GET['tab'] || ! isset( $_GET['tab'] ) ? 'tab-active' : ''; ?>" id="general_options">
-							<span><?php echo esc_html( 'Create Shortcode', 'feed-them-social' ); ?></span>
+							<span><?php echo esc_html__( 'Create Shortcode', 'feed-them-social' ); ?></span>
 						</label>
 
 						<label for="fts-tab2" class="fts-tab2 fts-tabbed <?php echo isset( $_GET['tab'] ) && 'global_options' === $_GET['tab'] ? 'tab-active' : ''; ?>" id="global_options">
-							<span><?php echo esc_html( 'Global Options', 'feed-them-social' ); ?></span>
+							<span><?php echo esc_html__( 'Global Options', 'feed-them-social' ); ?></span>
 						</label>
 
 						<div id="fts-tab-content1" class="fts-tab-content fts-hide-me <?php echo isset( $_GET['tab'] ) && 'general_options' === $_GET['tab'] || ! isset( $_GET['tab'] ) ? 'pane-active' : ''; ?>">
 							<section>
 
-								<h2 class="fts-logo-subheader"><?php echo esc_html( 'Create Shortcode for Social Network', 'feed-them-social' ); ?></h2>
-								<div class="use-of-plugin"><?php echo esc_html( 'Please select what type of feed you would like using the select option below. After setting your options click the green Generate Shortcode button, then copy and paste the shortcode to a page, post or widget.', 'feed-them-social' ); ?></div>
+								<h2 class="fts-logo-subheader"><?php echo esc_html__( 'Create Shortcode for Social Network', 'feed-them-social' ); ?></h2>
+								<div class="use-of-plugin"><?php echo esc_html__( 'Please select what type of feed you would like using the select option below. After setting your options click the green Generate Shortcode button, then copy and paste the shortcode to a page, post or widget.', 'feed-them-social' ); ?></div>
 
 								<form class="feed-them-social-admin-form" id="feed-selector-form">
 									<select id="shortcode-form-selector">
-										<option value=""><?php echo esc_html( 'Select a Social Network', 'feed-them-social' ); ?> </option>
-										<option value="fts-fb-page-shortcode-form"><?php echo esc_html( 'Facebook Feed', 'feed-them-social' ); ?></option>
-										<option value="combine-steams-shortcode-form"><?php echo esc_html( 'Combine Streams Feed', 'feed-them-social' ); ?></option>
-										<option value="twitter-shortcode-form"><?php echo esc_html( 'Twitter Feed', 'feed-them-social' ); ?></option>
-										<option value="instagram-shortcode-form"><?php echo esc_html( 'Instagram Feed', 'feed-them-social' ); ?></option>
-										<option value="youtube-shortcode-form"><?php echo esc_html( 'YouTube Feed' ); ?></option>
-										<option value="pinterest-shortcode-form"><?php echo esc_html( 'Pinterest Feed', 'feed-them-social' ); ?></option>
+										<option value=""><?php echo esc_html__( 'Select a Social Network', 'feed-them-social' ); ?> </option>
+										<option value="fts-fb-page-shortcode-form"><?php echo esc_html__( 'Facebook Feed', 'feed-them-social' ); ?></option>
+										<option value="combine-steams-shortcode-form"><?php echo esc_html__( 'Combine Streams Feed', 'feed-them-social' ); ?></option>
+										<option value="twitter-shortcode-form"><?php echo esc_html__( 'Twitter Feed', 'feed-them-social' ); ?></option>
+										<option value="instagram-shortcode-form"><?php echo esc_html__( 'Instagram Feed', 'feed-them-social' ); ?></option>
+										<option value="youtube-shortcode-form"><?php echo esc_html__( 'YouTube Feed', 'feed-them-social' ); ?></option>
+                                        <!--/ <option value="pinterest-shortcode-form"><?php echo esc_html__( 'Pinterest Feed', 'feed-them-social' ); ?></option>  -->
 									</select>
 								</form><!--/feed-them-social-admin-form-->
 
@@ -184,8 +184,8 @@ class FTS_Settings_Page {
 							">
 							<section>
 								<div class="feed-them-clear-cache">
-									<h2><?php echo esc_html( 'Clear All Cache Options', 'feed-them-social' ); ?></h2>
-									<div class="use-of-plugin"><?php echo esc_html( 'Please Clear Cache if you have changed a Feed Them Social Shortcode. This will Allow you to see the changes right away.', 'feed-them-social' ); ?></div>
+									<h2><?php echo esc_html__( 'Clear All Cache Options', 'feed-them-social' ); ?></h2>
+									<div class="use-of-plugin"><?php echo esc_html__( 'Please Clear Cache if you have changed a Feed Them Social Shortcode. This will Allow you to see the changes right away.', 'feed-them-social' ); ?></div>
 									<?php
 									if ( isset( $_GET['cache'] ) && 'clearcache' === $_GET['cache'] ) {
 										echo '<div class="feed-them-clear-cache-text">' . esc_html( $fts_functions->feed_them_clear_cache() ) . '</div>';
@@ -196,30 +196,30 @@ class FTS_Settings_Page {
 									?>
 
 									<form method="post" action="?page=feed-them-settings-page&cache=clearcache&tab=global_options">
-										<input class="feed-them-social-admin-submit-btn" type="submit" value="<?php echo esc_html( 'Clear All FTS Feeds Cache', 'feed-them-social' ); ?>"/>
+										<input class="feed-them-social-admin-submit-btn" type="submit" value="<?php echo esc_html__( 'Clear All FTS Feeds Cache', 'feed-them-social' ); ?>"/>
 									</form>
 								</div><!--/feed-them-clear-cache-->
 								<!-- custom option for padding -->
 								<form method="post" class="fts-color-settings-admin-form" action="options.php">
 									<p>
-										<label><?php echo esc_html( 'Cache Time', 'feed-them-social' ); ?></label>
+										<label><?php echo esc_html__( 'Cache Time', 'feed-them-social' ); ?></label>
 										<select id="fts_clear_cache_developer_mode" name="fts_clear_cache_developer_mode">
-											<option value=""><?php echo esc_html( 'Please choose an option', 'feed-them-social' ); ?></option>
-											<option value="86400" <?php echo '86400' === $fts_dev_mode_cache ? 'selected="selected"' : ''; ?>><?php echo esc_html( '1 Day ago (Suggested Default)', 'feed-them-social' ); ?></option>
-											<option value="172800" <?php echo '172800' === $fts_dev_mode_cache ? 'selected="selected"' : ''; ?>><?php echo esc_html( '2 Days', 'feed-them-social' ); ?></option>
-											<option value="259200" <?php echo '259200' === $fts_dev_mode_cache ? 'selected="selected"' : ''; ?>><?php echo esc_html( '3 Days', 'feed-them-social' ); ?></option>
-											<option value="604800" <?php echo '604800' === $fts_dev_mode_cache ? 'selected="selected"' : ''; ?>><?php echo esc_html( '1 Week', 'feed-them-social' ); ?></option>
-											<option value="1209600" <?php echo '1209600' === $fts_dev_mode_cache ? 'selected="selected"' : ''; ?>><?php echo esc_html( '2 Weeks', 'feed-them-social' ); ?></option>
-											<option value="1" <?php echo '1' === $fts_dev_mode_cache ? 'selected="selected"' : ''; ?>><?php echo esc_html( '(Developers Only) Clear cache on every page load', 'feed-them-social' ); ?></option>
+											<option value=""><?php echo esc_html__( 'Please choose an option', 'feed-them-social' ); ?></option>
+											<option value="86400" <?php echo '86400' === $fts_dev_mode_cache ? 'selected="selected"' : ''; ?>><?php echo esc_html__( '1 Day ago (Suggested Default)', 'feed-them-social' ); ?></option>
+											<option value="172800" <?php echo '172800' === $fts_dev_mode_cache ? 'selected="selected"' : ''; ?>><?php echo esc_html__( '2 Days', 'feed-them-social' ); ?></option>
+											<option value="259200" <?php echo '259200' === $fts_dev_mode_cache ? 'selected="selected"' : ''; ?>><?php echo esc_html__( '3 Days', 'feed-them-social' ); ?></option>
+											<option value="604800" <?php echo '604800' === $fts_dev_mode_cache ? 'selected="selected"' : ''; ?>><?php echo esc_html__( '1 Week', 'feed-them-social' ); ?></option>
+											<option value="1209600" <?php echo '1209600' === $fts_dev_mode_cache ? 'selected="selected"' : ''; ?>><?php echo esc_html__( '2 Weeks', 'feed-them-social' ); ?></option>
+											<option value="1" <?php echo '1' === $fts_dev_mode_cache ? 'selected="selected"' : ''; ?>><?php echo esc_html__( '(Developers Only) Clear cache on every page load', 'feed-them-social' ); ?></option>
 										</select>
 									</p>
-									<label><?php echo esc_html( 'Admin Bar', 'feed-them-social' ); ?></label>
+									<label><?php echo esc_html__( 'Admin Bar', 'feed-them-social' ); ?></label>
 									<select id="fts_admin_bar_menu" name="fts_admin_bar_menu">
 										<option value="<?php echo esc_attr( 'show-admin-bar-menu' ); ?>" <?php echo 'show-admin-bar-menu' === $fts_admin_bar_menu ? 'selected="selected"' : ''; ?>>
-											<?php echo esc_html( 'Show Admin Bar Menu', 'feed-them-social' ); ?>
+											<?php echo esc_html__( 'Show Admin Bar Menu', 'feed-them-social' ); ?>
 										</option>
 										<option value="<?php echo esc_attr( 'hide-admin-bar-menu' ); ?>" <?php echo 'hide-admin-bar-menu' === $fts_admin_bar_menu ? 'selected="selected"' : ''; ?>>
-											<?php echo esc_html( 'Hide Admin Bar Menu', 'feed-them-social' ); ?>
+											<?php echo esc_html__( 'Hide Admin Bar Menu', 'feed-them-social' ); ?>
 										</option>
 									</select>
 									<div class="feed-them-custom-css">
@@ -237,7 +237,7 @@ class FTS_Settings_Page {
 
 										?>
 										<div style="float:left; max-width:400px; margin-right:30px;">
-											<h2><?php echo esc_html( 'FaceBook & Twitter Date Format', 'feed-them-social' ); ?></h2>
+											<h2><?php echo esc_html__( 'FaceBook & Twitter Date Format', 'feed-them-social' ); ?></h2>
 
 											<fieldset>
 												<select id="fts-date-and-time-format" name="fts-date-and-time-format">
@@ -278,10 +278,10 @@ class FTS_Settings_Page {
 														<?php echo esc_html( date( 'Y/m/d @ G:i' ) ); ?>
 													</option>
 													<option value="<?php echo esc_attr( 'one-day-ago' ); ?>" <?php echo 'one-day-ago' === $fts_date_time_format ? 'selected="selected"' : ''; ?>>
-														<?php echo esc_html( 'One Day Ago' ); ?>
+														<?php echo esc_html__( 'One Day Ago', 'feed-them-social' ); ?>
 													</option>
 													<option value="<?php echo esc_attr( 'fts-custom-date' ); ?>" <?php echo 'fts-custom-date' === $fts_date_time_format ? 'selected="selected"' : ''; ?>>
-														<?php echo esc_html( 'Use Custom Date and Time Option Below', 'feed-them-social' ); ?>
+														<?php echo esc_html__( 'Use Custom Date and Time Option Below', 'feed-them-social' ); ?>
 													</option>
 												</select>
 											</fieldset>
@@ -306,50 +306,50 @@ class FTS_Settings_Page {
 											?>
 
 											<div class="custom_time_ago_wrap" style="display:none;">
-												<h2><?php echo esc_html( 'Translate words for 1 day ago option.', 'feed-them-social' ); ?></h2>
-												<label for="fts_language_second"><?php echo esc_html( 'second' ); ?></label>
+												<h2><?php echo esc_html__( 'Translate words for 1 day ago option.', 'feed-them-social' ); ?></h2>
+												<label for="fts_language_second"><?php echo esc_html__( 'second', 'feed-them-social' ); ?></label>
 												<input name="fts_language_second" type="text" value="<?php echo esc_attr( $fts_language_second ); ?>" size="25"/>
 												<br/>
-												<label for="fts_language_seconds"><?php echo esc_html( 'seconds' ); ?></label>
+												<label for="fts_language_seconds"><?php echo esc_html__( 'seconds', 'feed-them-social' ); ?></label>
 												<input name="fts_language_seconds" type="text" value="<?php echo esc_attr( $fts_language_seconds ); ?>" size="25"/>
 												<br/>
-												<label for="fts_language_minute"><?php echo esc_html( 'minute' ); ?></label>
+												<label for="fts_language_minute"><?php echo esc_html__( 'minute', 'feed-them-social' ); ?></label>
 												<input name="fts_language_minute" type="text" value="<?php echo esc_attr( $fts_language_minute ); ?>" size="25"/>
 												<br/>
-												<label for="fts_language_minutes"><?php echo esc_html( 'minutes' ); ?></label>
+												<label for="fts_language_minutes"><?php echo esc_html__( 'minutes', 'feed-them-social' ); ?></label>
 												<input name="fts_language_minutes" type="text" value="<?php echo esc_attr( $fts_language_minutes ); ?>" size="25"/>
 												<br/>
-												<label for="fts_language_hour"><?php echo esc_html( 'hour' ); ?></label>
+												<label for="fts_language_hour"><?php echo esc_html__( 'hour', 'feed-them-social' ); ?></label>
 												<input name="fts_language_hour" type="text" value="<?php echo esc_attr( $fts_language_hour ); ?>" size="25"/>
 												<br/>
-												<label for="fts_language_hours"><?php echo esc_html( 'hours' ); ?></label>
+												<label for="fts_language_hours"><?php echo esc_html__( 'hours', 'feed-them-social' ); ?></label>
 												<input name="fts_language_hours" type="text" value="<?php echo esc_attr( $fts_language_hours ); ?>" size="25"/>
 												<br/>
-												<label for="fts_language_day"><?php echo esc_html( 'day' ); ?></label>
+												<label for="fts_language_day"><?php echo esc_html__( 'day', 'feed-them-social' ); ?></label>
 												<input name="fts_language_day" type="text" value="<?php echo esc_attr( $fts_language_day ); ?>" size="25"/>
 												<br/>
-												<label for="fts_language_days"><?php echo esc_html( 'days' ); ?></label>
+												<label for="fts_language_days"><?php echo esc_html__( 'days', 'feed-them-social' ); ?></label>
 												<input name="fts_language_days" type="text" value="<?php echo esc_attr( $fts_language_days ); ?>" size="25"/>
 												<br/>
-												<label for="fts_language_week"><?php echo esc_html( 'week' ); ?></label>
+												<label for="fts_language_week"><?php echo esc_html__( 'week', 'feed-them-social' ); ?></label>
 												<input name="fts_language_week" type="text" value="<?php echo esc_attr( $fts_language_week ); ?>" size="25"/>
 												<br/>
-												<label for="fts_language_weeks"><?php echo esc_html( 'weeks' ); ?></label>
+												<label for="fts_language_weeks"><?php echo esc_html__( 'weeks', 'feed-them-social' ); ?></label>
 												<input name="fts_language_weeks" type="text" value="<?php echo esc_attr( $fts_language_weeks ); ?>" size="25"/>
 												<br/>
-												<label for="fts_language_month"><?php echo esc_html( 'month' ); ?></label>
+												<label for="fts_language_month"><?php echo esc_html__( 'month', 'feed-them-social' ); ?></label>
 												<input name="fts_language_month" type="text" value="<?php echo esc_attr( $fts_language_month ); ?>" size="25"/>
 												<br/>
-												<label for="fts_language_months"><?php echo esc_html( 'months' ); ?></label>
+												<label for="fts_language_months"><?php echo esc_html__( 'months', 'feed-them-social' ); ?></label>
 												<input name="fts_language_months" type="text" value="<?php echo esc_attr( $fts_language_months ); ?>" size="25"/>
 												<br/>
-												<label for="fts_language_year"><?php echo esc_html( 'year' ); ?></label>
+												<label for="fts_language_year"><?php echo esc_html__( 'year', 'feed-them-social' ); ?></label>
 												<input name="fts_language_year" type="text" value="<?php echo esc_attr( $fts_language_year ); ?>" size="25"/>
 												<br/>
-												<label for="fts_language_years"><?php echo esc_html( 'years' ); ?></label>
+												<label for="fts_language_years"><?php echo esc_html__( 'years', 'feed-them-social' ); ?></label>
 												<input name="fts_language_years" type="text" value="<?php echo esc_attr( $fts_language_years ); ?>" size="25"/>
 												<br/>
-												<label for="fts_language_ago"><?php echo esc_html( 'ago' ); ?></label>
+												<label for="fts_language_ago"><?php echo esc_html__( 'ago', 'feed-them-social' ); ?></label>
 												<input name="fts_language_ago" type="text" value="<?php echo esc_attr( $fts_language_ago ); ?>" size="25"/>
 
 											</div>
@@ -372,7 +372,7 @@ class FTS_Settings_Page {
 												});
 
 											</script>
-											<h2 style="border-top:0px; margin-bottom:4px !important;"><?php echo esc_html( 'Custom Date and Time', 'feed-them-social' ); ?></h2>
+											<h2 style="border-top:0px; margin-bottom:4px !important;"><?php echo esc_html__( 'Custom Date and Time', 'feed-them-social' ); ?></h2>
 											<div>
 												<?php echo ! empty( $fts_custom_date ) || ! empty( $fts_custom_time ) ? esc_html( date( get_option( 'fts-custom-date' ) . ' ' . get_option( 'fts-custom-time' ) ) ) : ''; ?>
 											</div>

--- a/admin/class-fts-system-info-page.php
+++ b/admin/class-fts-system-info-page.php
@@ -161,7 +161,6 @@ Twitter Consumer Key:       <?php echo esc_html( $twitter_options1 ) . "\n"; ?>
 Twitter Secret:             <?php echo esc_html( $twitter_options2 ) . "\n"; ?>
 Twitter Token:              <?php echo esc_html( $twitter_options3 ) . "\n"; ?>
 Twitter Token Secret:       <?php echo esc_html( $twitter_options4 ) . "\n"; ?>
-Pinterest Token:            <?php echo esc_html( $pinterest_token ) . "\n"; ?>
 Instagram Basic Token:      <?php echo esc_html( $instagram_basic_token ) . "\n"; ?>
 Instagram Business Token:   <?php echo esc_html( $instagram_business_token ) . "\n";
 		$youtube_options                               = get_option( 'youtube_custom_api_token' ) || get_option( 'youtube_custom_access_token' ) && get_option( 'youtube_custom_refresh_token' ) && get_option( 'youtube_custom_token_exp_time' ) ? 'Yes' : 'No';
@@ -226,3 +225,6 @@ Facebook Reviews Active: <?php echo isset( $fb_reviews_token ) && '' !== $fb_rev
 	}
 
 }//end class
+
+
+https://feedthemsocial.com/staging2/wp-admin/admin.php?page=fts-youtube-feed-styles-submenu-page&refresh_token=1%2F%2F041QAR9YNEJJwCgYIARAAGAQSNwF-L9IrXbwtTr2QRQRbRpvBG6esNTxqXGOJWQ2xVsZnfVmc59Ld3hFbuj4OgKOz9oS2hQBUP2k&access_token=ya29.a0AfH6SMCS8ZaAqjsqa9BhL_4nTOFPDbE3WRThhoDId_dMtB7nbdgznIlTYssaQx7sFvNkt10xWftOCxBYHKyrzWjZ5P4A_hKfcB6klt-rDvZrZ95rI6OulObYW82Mm3Z9rNo-Okg2sqdBWbiGa2ucln3HV7QcDdW0fZfODmA7o_o&expires_in=3599

--- a/admin/class-fts-twitter-options-page.php
+++ b/admin/class-fts-twitter-options-page.php
@@ -64,10 +64,10 @@ class FTS_Twitter_Options_Page {
 		?>
 		<div class="feed-them-social-admin-wrap">
 			<h1>
-				<?php echo esc_html( 'Twitter Feed Options', 'feed-them-social' ); ?>
+				<?php echo esc_html__( 'Twitter Feed Options', 'feed-them-social' ); ?>
 			</h1>
 			<div class="use-of-plugin">
-				<?php echo esc_html( 'Change the color of your twitter feed and more using the options below.', 'feed-them-social' ); ?>
+				<?php echo esc_html__( 'Change the color of your twitter feed and more using the options below.', 'feed-them-social' ); ?>
 			</div>
 			<!-- custom option for padding -->
 			<form method="post" class="fts-twitter-feed-options-form" action="options.php">
@@ -140,22 +140,22 @@ class FTS_Twitter_Options_Page {
 				<div class="feed-them-social-admin-input-wrap" style="padding-top: 0px">
 					<div class="fts-title-description-settings-page">
 						<h3>
-							<?php echo esc_html( 'Twitter API Token', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Twitter API Token', 'feed-them-social' ); ?>
 						</h3>
 						<p>
-							<?php echo esc_html( 'This is required to make the feed work. Simply click the button below and it will connect to your Twitter account to get an access token and access token secret, and it will return it in the input below. Then just click the save button and you will now be able to generate your Twitter feed.', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'This is required to make the feed work. Simply click the button below and it will connect to your Twitter account to get an access token and access token secret, and it will return it in the input below. Then just click the save button and you will now be able to generate your Twitter feed.', 'feed-them-social' ); ?>
 						</p>
 						<p>
 							<?php
 							echo sprintf(
-								esc_html( '%1$sLogin and get my Access Tokens%2$s', 'feed-them-social' ),
+								esc_html__( '%1$sLogin and get my Access Tokens%2$s', 'feed-them-social' ),
 								'<a href="' . esc_url( 'https://www.slickremix.com/get-twitter-token/?redirect_url=' . admin_url( 'admin.php?page=fts-twitter-feed-styles-submenu-page' ) . '&scope=manage_pages' ) . '" class="fts-twitter-get-access-token">',
 								'</a>'
 							);
 							?>
 						</p>
 					</div>
-					<a href="<?php echo esc_url( 'mailto:support@slickremix.com' ); ?>" target="_blank" class="fts-admin-button-no-work"><?php echo esc_html( 'Button not working?', 'feed-them-social' ); ?></a>
+					<a href="<?php echo esc_url( 'mailto:support@slickremix.com' ); ?>" target="_blank" class="fts-admin-button-no-work"><?php echo esc_html__( 'Button not working?', 'feed-them-social' ); ?></a>
 				</div>
 				<div class="fts-clear"></div>
 				<div class="feed-them-social-admin-input-wrap">
@@ -167,7 +167,7 @@ class FTS_Twitter_Options_Page {
 
 					<div class="fts-twitter-add-all-keys-click-option">
 						<label for="fts-custom-tokens-twitter">
-							<input type="checkbox" id="fts-custom-tokens-twitter" name="fts_twitter_custom_tokens" value="1" <?php echo checked( '1', '' === $extra_keys ); ?>> <?php echo esc_html( 'Add your own tokens?', 'feed-them-social' ); ?>
+							<input type="checkbox" id="fts-custom-tokens-twitter" name="fts_twitter_custom_tokens" value="1" <?php echo checked( '1', '' === $extra_keys ); ?>> <?php echo esc_html__( 'Add your own tokens?', 'feed-them-social' ); ?>
 						</label>
 					</div>
 
@@ -175,7 +175,7 @@ class FTS_Twitter_Options_Page {
 						<div class="twitter-extra-keys-text">
 							<?php
 							echo sprintf(
-								esc_html( 'Learn how to manually create the Consumer Key/Secret and the Access Token/Secret %1$shere%2$s.', 'feed-them-social' ),
+								esc_html__( 'Learn how to manually create the Consumer Key/Secret and the Access Token/Secret %1$shere%2$s.', 'feed-them-social' ),
 								'<a href="' . esc_url( 'https://www.slickremix.com/docs/how-to-get-api-keys-and-tokens-for-twitter/' ) . '" target="_blank">',
 								'</a>'
 							);
@@ -183,14 +183,14 @@ class FTS_Twitter_Options_Page {
 						</div>
 							<div class="feed-them-social-admin-input-wrap">
 								<div class="feed-them-social-admin-input-label fts-twitter-border-bottom-color-label">
-									<?php echo esc_html( 'Consumer Key (API Key)', 'feed-them-social' ); ?>
+									<?php echo esc_html__( 'Consumer Key (API Key)', 'feed-them-social' ); ?>
 								</div>
 								<input type="text" name="fts_twitter_custom_consumer_key" class="feed-them-social-admin-input" id="fts_twitter_custom_consumer_key" value="<?php echo esc_attr( get_option( 'fts_twitter_custom_consumer_key' ) ); ?>"/>
 								<div class="fts-clear"></div>
 							</div>
 							<div class="feed-them-social-admin-input-wrap">
 								<div class="feed-them-social-admin-input-label fts-twitter-border-bottom-color-label">
-									<?php echo esc_html( 'Consumer Secret (API Secret)', 'feed-them-social' ); ?>
+									<?php echo esc_html__( 'Consumer Secret (API Secret)', 'feed-them-social' ); ?>
 								</div>
 								<input type="text" name="fts_twitter_custom_consumer_secret" class="feed-them-social-admin-input" id="fts_twitter_custom_consumer_secret" value="<?php echo esc_attr( get_option( 'fts_twitter_custom_consumer_secret' ) ); ?>"/>
 								<div class="fts-clear"></div>
@@ -210,7 +210,7 @@ class FTS_Twitter_Options_Page {
 						?>
 						<div class="feed-them-social-admin-input-wrap">
 							<div class="feed-them-social-admin-input-label fts-twitter-border-bottom-color-label">
-								<?php echo esc_html( 'Access Token', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Access Token', 'feed-them-social' ); ?>
 							</div>
 							<input type="text" name="fts_twitter_custom_access_token" class="feed-them-social-admin-input" id="fts_twitter_custom_access_token" value="<?php echo esc_attr( $oath_token ); ?>"/>
 							<div class="fts-clear"></div>
@@ -218,7 +218,7 @@ class FTS_Twitter_Options_Page {
 
 						<div class="feed-them-social-admin-input-wrap">
 							<div class="feed-them-social-admin-input-label fts-twitter-border-bottom-color-label">
-								<?php echo esc_html( 'Access Token Secret', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Access Token Secret', 'feed-them-social' ); ?>
 							</div>
 							<input type="text" name="fts_twitter_custom_access_token_secret" class="feed-them-social-admin-input" id="fts_twitter_custom_access_token_secret" value="<?php echo esc_attr( $oauth_token_secret ); ?>"/>
 							<div class="fts-clear"></div>
@@ -230,12 +230,12 @@ class FTS_Twitter_Options_Page {
 							if ( ! empty( $fts_twitter_custom_access_token_secret ) && ! empty( $fts_twitter_custom_access_token_secret ) ) {
 								if ( 200 !== $test_connection->http_code || isset( $fetched_tweets->errors ) ) {
 									echo sprintf(
-										esc_html( '%1$sOh No, something\'s wrong. ', 'feed-them-social' ),
+										esc_html__( '%1$sOh No, something\'s wrong. ', 'feed-them-social' ),
 										'<div class="fts-failed-api-token">'
 									);
 									foreach ( $fetched_tweets->errors as $error ) {
 										echo sprintf(
-											esc_html( '%1$s%2$s%3$s You may have entered in the Access information incorrectly please re-enter and try again.%4$s', 'feed-them-social' ),
+											esc_html__( '%1$s%2$s%3$s You may have entered in the Access information incorrectly please re-enter and try again.%4$s', 'feed-them-social' ),
 											'<strong>',
 											esc_html( $error->message ),
 											'</strong>',
@@ -244,7 +244,7 @@ class FTS_Twitter_Options_Page {
 									}
 								} else {
 									echo sprintf(
-										esc_html( '%1$sYour access token is working! Generate your shortcode on the %2$sSettings Page%3$s.%4$s', 'feed-them-social' ),
+										esc_html__( '%1$sYour access token is working! Generate your shortcode on the %2$sSettings Page%3$s.%4$s', 'feed-them-social' ),
 										'<div class="fts-successful-api-token">',
 										'<a href="' . esc_url( 'admin.php?page=feed-them-settings-page' ) . '">',
 										'</a>',
@@ -255,7 +255,7 @@ class FTS_Twitter_Options_Page {
 								do_action( 'wp_ajax_fts_clear_cache_ajax' );
 							} else {
 								echo sprintf(
-									esc_html( '%1$sTo get started, please click the button above to retrieve your Access Token.%2$s', 'feed-them-social' ),
+									esc_html__( '%1$sTo get started, please click the button above to retrieve your Access Token.%2$s', 'feed-them-social' ),
 									'<div class="fts-failed-api-token get-started-message">',
 									'</div>'
 								);
@@ -270,19 +270,19 @@ class FTS_Twitter_Options_Page {
 					<div class="feed-them-social-admin-input-wrap">
 						<div class="fts-title-description-settings-page">
 							<h3>
-								<?php echo esc_html( 'Follow Button Options', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Follow Button Options', 'feed-them-social' ); ?>
 							</h3>
-							<?php echo esc_html( 'This will only show on regular feeds not combined feeds.', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'This will only show on regular feeds not combined feeds.', 'feed-them-social' ); ?>
 						</div>
 						<div class="feed-them-social-admin-input-label fts-twitter-text-color-label">
-							<?php echo esc_html( 'Show Follow Count', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Show Follow Count', 'feed-them-social' ); ?>
 						</div>
 						<select name="twitter_show_follow_count" id="twitter-show-follow-count" class="feed-them-social-admin-input">
 							<option <?php echo selected( $twitter_show_follow_count, 'no', false ); ?> value=" <?php echo esc_attr( 'no' ); ?>">
-								<?php echo esc_html( 'No', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'No', 'feed-them-social' ); ?>
 							</option>
 							<option <?php echo selected( $twitter_show_follow_count, 'yes', false ); ?> value="<?php echo esc_attr( 'yes' ); ?>">
-								<?php echo esc_html( 'Yes', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Yes', 'feed-them-social' ); ?>
 							</option>
 						</select>
 						<div class="fts-clear"></div>
@@ -291,14 +291,14 @@ class FTS_Twitter_Options_Page {
 
 					<div class="feed-them-social-admin-input-wrap">
 						<div class="feed-them-social-admin-input-label fts-twitter-text-color-label">
-							<?php echo esc_html( 'Show Follow Button', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Show Follow Button', 'feed-them-social' ); ?>
 						</div>
 						<select name="twitter_show_follow_btn" id="twitter-show-follow-btn" class="feed-them-social-admin-input">
 							<option <?php echo selected( $twitter_show_follow_btn, 'no', false ); ?> value="<?php echo esc_attr( 'no' ); ?>">
-								<?php echo esc_html( 'No', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'No', 'feed-them-social' ); ?>
 							</option>
 							<option <?php echo selected( $twitter_show_follow_btn, 'yes', false ); ?> value="<?php echo esc_attr( 'yes' ); ?>">
-								<?php echo esc_html( 'Yes', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Yes', 'feed-them-social' ); ?>
 							</option>
 						</select>
 						<div class="fts-clear"></div>
@@ -307,17 +307,17 @@ class FTS_Twitter_Options_Page {
 
 					<div class="feed-them-social-admin-input-wrap">
 						<div class="feed-them-social-admin-input-label fts-twitter-text-color-label">
-							<?php echo esc_html( 'Placement of Follow Button', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Placement of Follow Button', 'feed-them-social' ); ?>
 						</div>
 						<select name="twitter_show_follow_btn_where" id="twitter-show-follow-btn-where" class="feed-them-social-admin-input">
 							<option>
-								<?php echo esc_html( 'Please Select Option', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Please Select Option', 'feed-them-social' ); ?>
 							</option>
 							<option <?php echo selected( $twitter_show_follow_btn_where, 'twitter-follow-above', false ); ?> value="<?php echo esc_attr( 'twitter-follow-above' ); ?>">
-								<?php echo esc_html( 'Show Above Feed', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Show Above Feed', 'feed-them-social' ); ?>
 							</option>
 							<option <?php echo selected( $twitter_show_follow_btn_where, 'twitter-follow-below', false ); ?> value="<?php echo esc_attr( 'twitter-follow-below' ); ?>">
-								<?php echo esc_html( 'Show Below Feed', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Show Below Feed', 'feed-them-social' ); ?>
 							</option>
 						</select>
 						<div class="fts-clear"></div>
@@ -327,18 +327,18 @@ class FTS_Twitter_Options_Page {
 					<div class="feed-them-social-admin-input-wrap">
 						<div class="fts-title-description-settings-page">
 							<h3>
-								<?php echo esc_html( 'Video Player Options', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Video Player Options', 'feed-them-social' ); ?>
 							</h3>
 						</div>
 						<div class="feed-them-social-admin-input-label fts-twitter-text-color-label">
-							<?php echo esc_html( 'Show videos', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Show videos', 'feed-them-social' ); ?>
 						</div>
 						<select name="twitter_allow_videos" id="twitter-allow-videos" class="feed-them-social-admin-input">
 							<option <?php echo selected( $twitter_allow_videos, 'no', false ); ?> value="<?php echo esc_attr( 'no' ); ?>">
-								<?php echo esc_html( 'No', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'No', 'feed-them-social' ); ?>
 							</option>
 							<option <?php echo selected( $twitter_allow_videos, 'yes', false ); ?> value="<?php echo esc_attr( 'yes' ); ?>">
-								<?php echo esc_html( 'Yes', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Yes', 'feed-them-social' ); ?>
 							</option>
 						</select>
 						<div class="fts-clear"></div>
@@ -349,7 +349,7 @@ class FTS_Twitter_Options_Page {
 						<div class="feed-them-social-admin-input-label fts-twitter-text-color-label">
 							<?php
 							echo sprintf(
-								esc_html( 'Convert shortlinks for video%1$sLike bitly etc. May slow load time slightly%2$s.', 'feed-them-social' ),
+								esc_html__( 'Convert shortlinks for video%1$sLike bitly etc. May slow load time slightly%2$s.', 'feed-them-social' ),
 								'<br/><small>',
 								'</small>'
 							);
@@ -358,10 +358,10 @@ class FTS_Twitter_Options_Page {
 						<select name="twitter_allow_shortlink_conversion" id="twitter-allow-shortlink-conversion" class="feed-them-social-admin-input">
 							<option
 							<?php echo selected( $twitter_allow_shortlink_conversion, 'no', false ); ?> value="<?php echo esc_attr( 'no' ); ?>">
-								<?php echo esc_html( 'No', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'No', 'feed-them-social' ); ?>
 							</option>
 							<option <?php echo selected( $twitter_allow_shortlink_conversion, 'yes', false ); ?> value="<?php echo esc_attr( 'yes' ); ?>">
-								<?php echo esc_html( 'Yes', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Yes', 'feed-them-social' ); ?>
 							</option>
 						</select>
 						<div class="fts-clear"></div>
@@ -371,19 +371,19 @@ class FTS_Twitter_Options_Page {
 					<div class="feed-them-social-admin-input-wrap">
 						<div class="fts-title-description-settings-page">
 							<h3>
-								<?php echo esc_html( 'Profile Photo Option', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Profile Photo Option', 'feed-them-social' ); ?>
 							</h3>
 						</div>
 						<div class="feed-them-social-admin-input-label fts-twitter-text-color-label">
-							<?php echo esc_html( 'Hide Profile Photo', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Hide Profile Photo', 'feed-them-social' ); ?>
 						</div>
 						<select name="twitter_full_width" id="twitter-full-width" class="feed-them-social-admin-input">
 							<option
 							<?php echo selected( $twitter_full_width, 'no', false ); ?> value="<?php echo esc_attr( 'no' ); ?>">
-								<?php echo esc_html( 'No', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'No', 'feed-them-social' ); ?>
 							</option>
 							<option <?php echo selected( $twitter_full_width, 'yes', false ); ?> value="<?php echo esc_attr( 'yes' ); ?>">
-								<?php echo esc_html( 'Yes', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Yes', 'feed-them-social' ); ?>
 							</option>
 						</select>
 						<div class="fts-clear"></div>
@@ -393,23 +393,23 @@ class FTS_Twitter_Options_Page {
 					<div class="feed-them-social-admin-input-wrap">
 						<div class="fts-title-description-settings-page">
 							<h3>
-								<?php echo esc_html( 'Style Options', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Style Options', 'feed-them-social' ); ?>
 							</h3>
 						</div>
 
 						<div class="feed-them-social-admin-input-wrap">
 							<div class="feed-them-social-admin-input-label fts-twitter-text-color-label">
-								<?php echo esc_html( 'Hide Images in Posts', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Hide Images in Posts', 'feed-them-social' ); ?>
 							</div>
 							<select name="fts_twitter_hide_images_in_posts" id="fts_twitter_hide_images_in_posts" class="feed-them-social-admin-input">
 								<option value="">
-									<?php echo esc_html( 'Please Select Option', 'feed-them-social' ); ?>
+									<?php echo esc_html__( 'Please Select Option', 'feed-them-social' ); ?>
 								</option>
 								<option <?php echo selected( $fts_twitter_hide_images_in_posts, 'no', false ); ?> value="<?php echo esc_attr( 'no' ); ?>">
-									<?php echo esc_html( 'No', 'feed-them-social' ); ?>
+									<?php echo esc_html__( 'No', 'feed-them-social' ); ?>
 								</option>
 								<option <?php echo selected( $fts_twitter_hide_images_in_posts, 'yes', false ); ?> value="<?php echo esc_attr( 'yes' ); ?>">
-									<?php echo esc_html( 'Yes', 'feed-them-social' ); ?>
+									<?php echo esc_html__( 'Yes', 'feed-them-social' ); ?>
 								</option>
 							</select>
 							<div class="fts-clear"></div>
@@ -418,7 +418,7 @@ class FTS_Twitter_Options_Page {
 
 						<div class="feed-them-social-admin-input-wrap">
 							<div class="feed-them-social-admin-input-label">
-								<?php echo esc_html( 'Max-width for Feed Images', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Max-width for Feed Images', 'feed-them-social' ); ?>
 							</div>
 							<input type="text" name="twitter_max_image_width" class="feed-them-social-admin-input" placeholder="500px" value="<?php echo esc_attr( get_option( 'twitter_max_image_width' ) ); ?>"/>
 							<div class="fts-clear"></div>
@@ -427,7 +427,7 @@ class FTS_Twitter_Options_Page {
 
 						<div class="feed-them-social-admin-input-wrap">
 							<div class="feed-them-social-admin-input-label fts-twitter-text-size-label">
-								<?php echo esc_html( 'Feed Description Text Size', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Feed Description Text Size', 'feed-them-social' ); ?>
 							</div>
 							<input type="text" name="twitter_text_size" class="feed-them-social-admin-input twitter-text-size-input" id="twitter-text-size-input" placeholder="12px" value="<?php echo esc_attr( get_option( 'twitter_text_size' ) ); ?>"/>
 							<div class="fts-clear"></div>
@@ -436,7 +436,7 @@ class FTS_Twitter_Options_Page {
 
 						<div class="feed-them-social-admin-input-wrap">
 							<div class="feed-them-social-admin-input-label fts-twitter-text-color-label">
-								<?php echo esc_html( 'Feed Text Color', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Feed Text Color', 'feed-them-social' ); ?>
 							</div>
 							<input type="text" name="twitter_text_color" class="feed-them-social-admin-input twitter-text-color-input color {hash:true,caps:false,required:false,adjust:false,pickerFaceColor:'#eee',pickerFace:3,pickerBorder:0,pickerInsetColor:'white'}" id="twitter-text-color-input" placeholder="#222" value="<?php echo esc_attr( get_option( 'twitter_text_color' ) ); ?>"/>
 							<div class="fts-clear"></div>
@@ -445,7 +445,7 @@ class FTS_Twitter_Options_Page {
 
 						<div class="feed-them-social-admin-input-wrap">
 							<div class="feed-them-social-admin-input-label fts-twitter-link-color-label">
-								<?php echo esc_html( 'Feed Link Color', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Feed Link Color', 'feed-them-social' ); ?>
 							</div>
 							<input type="text" name="twitter_link_color" class="feed-them-social-admin-input twitter-link-color-input color {hash:true,caps:false,required:false,adjust:false,pickerFaceColor:'#eee',pickerFace:3,pickerBorder:0,pickerInsetColor:'white'}" id="twitter-link-color-input" placeholder="#222" value="<?php echo esc_attr( get_option( 'twitter_link_color' ) ); ?>"/>
 							<div class="fts-clear"></div>
@@ -454,7 +454,7 @@ class FTS_Twitter_Options_Page {
 
 						<div class="feed-them-social-admin-input-wrap">
 							<div class="feed-them-social-admin-input-label fts-twitter-link-color-hover-label">
-								<?php echo esc_html( 'Feed Link Color Hover', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Feed Link Color Hover', 'feed-them-social' ); ?>
 							</div>
 							<input type="text" name="twitter_link_color_hover" class="feed-them-social-admin-input twitter-link-color-hover-input color {hash:true,caps:false,required:false,adjust:false,pickerFaceColor:'#eee',pickerFace:3,pickerBorder:0,pickerInsetColor:'white'}" id="twitter-link-color-hover-input" placeholder="#ddd" value="<?php echo esc_attr( get_option( 'twitter_link_color_hover' ) ); ?>"/>
 							<div class="fts-clear"></div>
@@ -463,7 +463,7 @@ class FTS_Twitter_Options_Page {
 
 						<div class="feed-them-social-admin-input-wrap">
 							<div class="feed-them-social-admin-input-label fts-twitter-feed-width-label">
-								<?php echo esc_html( 'Feed Width', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Feed Width', 'feed-them-social' ); ?>
 							</div>
 							<input type="text" name="twitter_feed_width" class="feed-them-social-admin-input twitter-feed-width-input" id="twitter-feed-width-input" placeholder="500px" value="<?php echo esc_attr( get_option( 'twitter_feed_width' ) ); ?>"/>
 							<div class="fts-clear"></div>
@@ -474,7 +474,7 @@ class FTS_Twitter_Options_Page {
 							<div class="feed-them-social-admin-input-label fts-twitter-feed-margin-label">
 								<?php
 								echo sprintf(
-									esc_html( 'Feed Margin %1$sTo center feed type auto%2$s', 'feed-them-social' ),
+									esc_html__( 'Feed Margin %1$sTo center feed type auto%2$s', 'feed-them-social' ),
 									'<br/><small>',
 									'</small>'
 								);
@@ -487,7 +487,7 @@ class FTS_Twitter_Options_Page {
 
 						<div class="feed-them-social-admin-input-wrap">
 							<div class="feed-them-social-admin-input-label fts-twitter-feed-padding-label">
-								<?php echo esc_html( 'Feed Padding', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'Feed Padding', 'feed-them-social' ); ?>
 							</div>
 							<input type="text" name="twitter_feed_padding" class="feed-them-social-admin-input twitter-feed-padding-input" id="twitter-feed-padding-input" placeholder="10px" value="<?php echo esc_attr( get_option( 'twitter_feed_padding' ) ); ?>"/>
 							<div class="fts-clear"></div>

--- a/admin/class-fts-youtube-options-page.php
+++ b/admin/class-fts-youtube-options-page.php
@@ -43,10 +43,10 @@ class FTS_Youtube_Options_Page {
 		?>
 		<div class="feed-them-social-admin-wrap">
 			<h1>
-				<?php echo esc_html( 'Feed Options', 'feed-them-social' ); ?>
+				<?php echo esc_html__( 'Feed Options', 'feed-them-social' ); ?>
 			</h1>
 			<div class="use-of-plugin">
-				<?php echo esc_html( 'Add a follow button and position it using the options below. This option will not work for combined feeds.', 'feed-them-social' ); ?>
+				<?php echo esc_html__( 'Add a follow button and position it using the options below. This option will not work for combined feeds.', 'feed-them-social' ); ?>
 			</div>
 
 			<!-- custom option for padding -->
@@ -78,14 +78,14 @@ class FTS_Youtube_Options_Page {
 				<div class="feed-them-social-admin-input-wrap" style="padding-top: 0">
 					<div class="fts-title-description-settings-page">
 						<h3>
-							<?php echo esc_html( 'YouTube API Key', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'YouTube API Key', 'feed-them-social' ); ?>
 						</h3>
-						<p><?php echo esc_html( 'This is required to make the feed work. Simply click the button below and it will connect to your YouTube account to get an access token and access token secret, and it will return it in the input below. Then just click the save button and you will now be able to generate your YouTube feed.', 'feed-them-social' ); ?>
+						<p><?php echo esc_html__( 'This is required to make the feed work. Simply click the button below and it will connect to your YouTube account to get an access token and access token secret, and it will return it in the input below. Then just click the save button and you will now be able to generate your YouTube feed.', 'feed-them-social' ); ?>
 						</p>
 						<p>
 							<?php
 							echo sprintf(
-								esc_html( '%1$sLogin and get my Access Token (API key)%2$s', 'feed-them-social' ),
+								esc_html__( '%1$sLogin and get my Access Token (API key)%2$s', 'feed-them-social' ),
 								'<a href="' . esc_url( 'https://www.slickremix.com/youtube-token/?redirect_url=' . admin_url( 'admin.php?page=fts-youtube-feed-styles-submenu-page' ) ) . '" class="fts-youtube-get-access-token">',
 								'</a>'
 							);
@@ -114,12 +114,12 @@ class FTS_Youtube_Options_Page {
 					<div class="fts-clear"></div>
 
 					<div class="youtube-extra-keys" style="<?php echo esc_attr( $extra_keys ); ?>">
-						<div class="youtube-extra-keys-text" style="<?php echo esc_attr( $extra_keys_no ); ?>"><?php echo esc_html( 'Learn how to manually create your own YouTube API Key', 'feed-them-social' ); ?>
-							<a href="<?php echo esc_url( 'https://www.slickremix.com/docs/get-api-key-for-youtube/' ); ?>" target="_blank"><?php echo esc_html( 'here', 'feed-them-social' ); ?></a>.
+						<div class="youtube-extra-keys-text" style="<?php echo esc_attr( $extra_keys_no ); ?>"><?php echo esc_html__( 'Learn how to manually create your own YouTube API Key', 'feed-them-social' ); ?>
+							<a href="<?php echo esc_url( 'https://www.slickremix.com/docs/get-api-key-for-youtube/' ); ?>" target="_blank"><?php echo esc_html__( 'here', 'feed-them-social' ); ?></a>.
 						</div>
 
 						<div class="feed-them-social-admin-input-label fts-youtube-border-bottom-color-label">
-							<?php echo esc_html( 'API Key Required', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'API Key Required', 'feed-them-social' ); ?>
 						</div>
 
 						<input type="text" name="youtube_custom_api_token" class="feed-them-social-admin-input" id="youtube_custom_api_token" value="<?php echo esc_attr( get_option( 'youtube_custom_api_token' ) ); ?>"/>
@@ -130,14 +130,14 @@ class FTS_Youtube_Options_Page {
 				<div class="hide-button-tokens-options" style="<?php echo esc_attr( $extra_keys_no ); ?>">
 					<div class="feed-them-social-admin-input-wrap">
 						<div class="feed-them-social-admin-input-label">
-							<?php echo esc_html( 'Refresh Token', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Refresh Token', 'feed-them-social' ); ?>
 						</div>
 						<input type="text" name="youtube_custom_refresh_token" class="feed-them-social-admin-input" id="youtube_custom_refresh_token" value="<?php echo esc_attr( get_option( 'youtube_custom_refresh_token' ) ); ?>"/>
 						<div class="fts-clear"></div>
 					</div>
 					<div class="feed-them-social-admin-input-wrap" style="margin-bottom:0;">
 						<div class="feed-them-social-admin-input-label">
-							<?php echo esc_html( 'Access Token', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Access Token', 'feed-them-social' ); ?>
 						</div>
 						<input type="text" name="youtube_custom_access_token" class="feed-them-social-admin-input" id="youtube_custom_access_token" value="<?php echo esc_attr( get_option( 'youtube_custom_access_token' ) ); ?>"/>
 						<div class="fts-clear"></div>
@@ -152,7 +152,7 @@ class FTS_Youtube_Options_Page {
 						?>
 							display:none<?php } ?>">
 						<div class="feed-them-social-admin-input-label">
-							<?php echo esc_html( 'Expiration Time for Access Token', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Expiration Time for Access Token', 'feed-them-social' ); ?>
 						</div>
 						<input type="text" name="youtube_custom_tokenecho esc_htmlxp_time" class="feed-them-social-admin-input" id="youtube_custom_tokenecho esc_htmlxp_time" value="<?php echo esc_attr( get_option( 'youtube_custom_tokenecho esc_htmlxp_time' ) ); ?>"/>
 						<div class="fts-clear"></div>
@@ -168,7 +168,7 @@ class FTS_Youtube_Options_Page {
 						});
 					</script>
 					<?php
-					if ( isset( $_GET['refresh_token'] ) && isset( $_GET['access_token'] ) && isset( $_GET['expires_in'] ) ) {
+					if ( isset( $_GET['refresh_token'] ) && isset( $_GET['code'] ) && isset( $_GET['expires_in'] ) ) {
 						// START AJAX TO SAVE TOKEN TO DB RIGHT AWAY SO WE CAN DO OUR NEXT SET OF CHECKS
 						// new token action!
 						$fts_functions->feed_them_youtube_refresh_token();
@@ -226,7 +226,7 @@ class FTS_Youtube_Options_Page {
 						// Error Check!
 						if ( ! isset( $test_app_token_response->error->errors[0]->reason ) && ! empty( $youtube_api_key ) || ! isset( $test_app_token_response->error->errors[0]->reason ) && ! empty( $youtube_access_token ) && empty( $youtube_api_key ) ) {
 							echo sprintf(
-								esc_html( '%1$s Your %2$s is working! Generate your shortcode on the %3$s settings page.%4$s %5$s', 'feed-them-social' ),
+								esc_html__( '%1$s Your %2$s is working! Generate your shortcode on the %3$s settings page.%4$s %5$s', 'feed-them-social' ),
 								'<div class="fts-successful-api-token">',
 								esc_html( $type_of_key ),
 								'<a href="' . esc_url( 'admin.php?page=feed-them-settings-page' ) . '">',
@@ -235,7 +235,7 @@ class FTS_Youtube_Options_Page {
 							);
 						} elseif ( isset( $user_id->error->errors[0]->reason ) && ! empty( $youtube_api_key ) || ! isset( $user_id->error->errors[0]->reason ) && ! empty( $youtube_access_token ) ) {
 							echo sprintf(
-								esc_html( '%1$s This %2$s does not appear to be valid. YouTube responded with: %3$s %4$s ', 'feed-them-social' ),
+								esc_html__( '%1$s This %2$s does not appear to be valid. YouTube responded with: %3$s %4$s ', 'feed-them-social' ),
 								'<div class="fts-failed-api-token">',
 								esc_html( $type_of_key ),
 								esc_html( $user_id->errors[0]->reason ),
@@ -244,7 +244,7 @@ class FTS_Youtube_Options_Page {
 						}
 						if ( empty( $youtube_api_key ) && empty( $youtube_access_token ) ) {
 							echo sprintf(
-								esc_html( '%1$s You must click the button above or register for an API token to use the YouTube feed.%2$s', 'feed-them-social' ),
+								esc_html__( '%1$s You must click the button above or register for an API token to use the YouTube feed.%2$s', 'feed-them-social' ),
 								'<div class="fts-failed-api-token">',
 								'</div>'
 							);
@@ -259,20 +259,20 @@ class FTS_Youtube_Options_Page {
 
 				<div class="feed-them-social-admin-input-wrap">
 					<div class="fts-title-description-settings-page">
-						<h3><?php echo esc_html( 'Follow Button Options', 'feed-them-social' ); ?></h3>
+						<h3><?php echo esc_html__( 'Follow Button Options', 'feed-them-social' ); ?></h3>
 					</div>
-					<div class="feed-them-social-admin-input-label fts-youtube-text-color-label"><?php echo esc_html( 'Show Follow Button', 'feed-them-social' ); ?></div>
+					<div class="feed-them-social-admin-input-label fts-youtube-text-color-label"><?php echo esc_html__( 'Show Follow Button', 'feed-them-social' ); ?></div>
 
 					<select name="youtube_show_follow_btn" id="youtube-show-follow-btn"
 							class="feed-them-social-admin-input">
 						<option
 							<?php echo selected( $fts_youtube_show_follow_btn, 'yes', false ); ?>
 								value="<?php echo esc_attr( 'yes' ); ?>">
-							<?php echo esc_html( 'Yes', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Yes', 'feed-them-social' ); ?>
 						</option>
 						<option <?php echo selected( $fts_youtube_show_follow_btn, 'no', false ); ?>
 								value="<?php echo esc_attr( 'no' ); ?>">
-							<?php echo esc_html( 'No', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'No', 'feed-them-social' ); ?>
 						</option>
 					</select>
 
@@ -280,20 +280,20 @@ class FTS_Youtube_Options_Page {
 				</div><!--/fts-youtube-feed-styles-input-wrap-->
 
 				<div class="feed-them-social-admin-input-wrap">
-					<div class="feed-them-social-admin-input-label fts-youtube-text-color-label"><?php echo esc_html( 'Placement of the Buttons', 'feed-them-social' ); ?></div>
+					<div class="feed-them-social-admin-input-label fts-youtube-text-color-label"><?php echo esc_html__( 'Placement of the Buttons', 'feed-them-social' ); ?></div>
 
 					<select name="youtube_show_follow_btn_where" id="youtube-show-follow-btn-where"
 							class="feed-them-social-admin-input">
-						<option><?php echo esc_html( 'Please Select Option', 'feed-them-social' ); ?></option>
+						<option><?php echo esc_html__( 'Please Select Option', 'feed-them-social' ); ?></option>
 						<option
 							<?php echo selected( $fts_youtube_show_follow_btn_where, 'youtube-follow-above', false ); ?>
 								value="<?php echo esc_attr( 'youtube-follow-above' ); ?>">
-							<?php echo esc_html( 'Show Above Feed', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Show Above Feed', 'feed-them-social' ); ?>
 						</option>
 						<option
 							<?php echo selected( $fts_youtube_show_follow_btn_where, 'youtube-follow-below', false ); ?>
 								value="<?php echo esc_attr( 'youtube-follow-below' ); ?>">
-							<?php echo esc_html( 'Show Below Feed', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Show Below Feed', 'feed-them-social' ); ?>
 						</option>
 					</select>
 
@@ -306,12 +306,12 @@ class FTS_Youtube_Options_Page {
 				<div class="feed-them-social-admin-input-wrap">
 					<div class="fts-title-description-settings-page">
 						<h3>
-							<?php echo esc_html( 'Load More Button Styles & Options', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Load More Button Styles & Options', 'feed-them-social' ); ?>
 						</h3>
 					</div>
 					<div class="feed-them-social-admin-input-wrap">
 						<div class="feed-them-social-admin-input-label fts-fb-loadmore-background-color-label">
-							<?php echo esc_html( 'Button Color', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Button Color', 'feed-them-social' ); ?>
 						</div>
 						<input type="text" name="youtube_loadmore_background_color" class="feed-them-social-admin-input fb-loadmore-background-color-input color {hash:true,caps:false,required:false,adjust:false,pickerFaceColor:'#eee',pickerFace:3,pickerBorder:0,pickerInsetColor:'white'}" id="youtube-loadmore-background-color-input" placeholder="#ddd" value="<?php echo esc_attr( get_option( 'youtube_loadmore_background_color' ) ); ?>"/>
 						<div class="fts-clear"></div>
@@ -320,7 +320,7 @@ class FTS_Youtube_Options_Page {
 
 					<div class="feed-them-social-admin-input-wrap">
 						<div class="feed-them-social-admin-input-label fts-fb-border-bottom-color-label">
-							<?php echo esc_html( 'Text Color', 'feed-them-social' ); ?>
+							<?php echo esc_html__( 'Text Color', 'feed-them-social' ); ?>
 						</div>
 						<input type="text" name="youtube_loadmore_text_color" class="feed-them-social-admin-input fb-loadmore-text-color-input color {hash:true,caps:false,required:false,adjust:false,pickerFaceColor:'#eee',pickerFace:3,pickerBorder:0,pickerInsetColor:'white'}" id="youtube-loadmore-text-color-input" placeholder="#ddd" value="<?php echo esc_attr( get_option( 'youtube_loadmore_text_color' ) ); ?>"/>
 						<div class="fts-clear"></div>
@@ -329,7 +329,7 @@ class FTS_Youtube_Options_Page {
 
 					<div class="feed-them-social-admin-input-wrap">
 						<div class="feed-them-social-admin-input-label">
-							<?php echo esc_html( '"Load More" Text', 'feed-them-social' ); ?>
+							<?php echo esc_html__( '"Load More" Text', 'feed-them-social' ); ?>
 						</div>
 						<input type="text" name="youtube_load_more_text" class="feed-them-social-admin-input" id="youtube_load_more_text" placeholder="Load More" value="<?php echo esc_attr( get_option( 'youtube_load_more_text' ) ); ?>"/>
 						<div class="clear"></div>
@@ -338,7 +338,7 @@ class FTS_Youtube_Options_Page {
 
 					<div class="feed-them-social-admin-input-wrap">
 						<div class="feed-them-social-admin-input-label">
-							<?php echo esc_html( '"No More Videos" Text', 'feed-them-social' ); ?>
+							<?php echo esc_html__( '"No More Videos" Text', 'feed-them-social' ); ?>
 						</div>
 						<input type="text" name="youtube_no_more_videos_text" class="feed-them-social-admin-input" id="youtube_no_more_videos_text" placeholder="No More Videos" value="<?php echo esc_attr( get_option( 'youtube_no_more_videos_text' ) ); ?>"/>
 						<div class="clear"></div>
@@ -346,7 +346,7 @@ class FTS_Youtube_Options_Page {
 					<!--/fts-youtube-feed-styles-input-wrap-->
 
 					<?php } // END premium ?>
-					<input type="submit" class="feed-them-social-admin-submit-btn" value="<?php echo esc_html( 'Save All Changes' ); ?>"/>
+					<input type="submit" class="feed-them-social-admin-submit-btn" value="<?php echo esc_html__( 'Save All Changes', 'feed-them-social' ); ?>"/>
 					<?php } ?>
 			</form>
 		</div>

--- a/feed-them.php
+++ b/feed-them.php
@@ -4,23 +4,23 @@
  *
  * This class is what initiates the Feed Them Social class
  *
- * Plugin Name: Feed Them Social - for Twitter feed, Youtube, Pinterest and more
+ * Plugin Name: Feed Them Social - for Twitter feed, Youtube, and more
  * Plugin URI: https://feedthemsocial.com/
- * Description: Display a Custom Facebook feed, Instagram feed, Twitter feed, Pinterest feed & YouTube feed on pages, posts or widgets.
- * Version: 2.9.1
+ * Description: Display a Custom Facebook feed, Instagram feed, Twitter feed and YouTube feed on pages, posts or widgets.
+ * Version: 2.9.2
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 4.0.0
  * Tested up to: WordPress 5.6.0
- * Stable tag: 2.9.1
+ * Stable tag: 2.9.2
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    2.9.1
+ * @version    2.9.2
  * @package    FeedThemSocial/Core
- * @copyright  Copyright (c) 2012-2020 SlickRemix
+ * @copyright  Copyright (c) 2012-2021 SlickRemix
  *
  * Need Support: https://wordpress.org/support/plugin/feed-them-social
  * Paid Extension Support: https://www.slickremix.com/my-account/#tab-support
@@ -31,7 +31,7 @@
  *
  * Makes sure any js or css changes are reloaded properly. Added to enqued css and js files throughout!
  */
-define( 'FTS_CURRENT_VERSION', '2.9.1' );
+define( 'FTS_CURRENT_VERSION', '2.9.2' );
 
 define( 'FEED_THEM_SOCIAL_NOTICE_STATUS', get_option( 'rating_fts_slick_notice', false ) );
 
@@ -127,7 +127,7 @@ final class Feed_Them_Social {
             self::$instance->instagram_feed = new feedthemsocial\FTS_Instagram_Feed();
 
             // Pinterest!
-            self::$instance->pinterest_feed = new feedthemsocial\FTS_Pinterest_Feed();
+            // self::$instance->pinterest_feed = new feedthemsocial\FTS_Pinterest_Feed();
 
             // Youtube!
             self::$instance->youtube_feed = new feedthemsocial\FTS_Youtube_Feed_Free();
@@ -169,7 +169,7 @@ final class Feed_Them_Social {
     public function fts_update_notice() {
         // Check the transient to see if we've just updated the plugin!
         if ( get_transient( 'fts_updated' ) ) {
-            echo '<div class="notice notice-success updated is-dismissible"><p>' . esc_html( 'Thanks for updating Feed Them Social. We have deleted the cache in our plugin so you can view any changes we have made.', 'feed-them-social' ) . '</p></div>';
+            echo '<div class="notice notice-success updated is-dismissible"><p>' . esc_html__( 'Thanks for updating Feed Them Social. We have deleted the cache in our plugin so you can view any changes we have made.', 'feed-them-social' ) . '</p></div>';
             delete_transient( 'fts_updated' );
         }
     }
@@ -185,7 +185,7 @@ final class Feed_Them_Social {
         if ( get_transient( 'fts_activated' ) ) {
             echo '<div class="notice notice-success updated is-dismissible"><p>';
             echo sprintf(
-                esc_html( 'Thanks for installing Feed Them Social. To get started please view our %1$sSettings%2$s page.', 'feed-them-social' ),
+                esc_html__( 'Thanks for installing Feed Them Social. To get started please view our %1$sSettings%2$s page.', 'feed-them-social' ),
                 '<a href="' . esc_url( 'admin.php?page=feed-them-settings-page' ) . '">',
                 '</a>'
             );
@@ -324,7 +324,7 @@ final class Feed_Them_Social {
     public function fts_required_php_check1() {
         echo '<div class="error"><p>';
         echo sprintf(
-            esc_html( '%1$s Feed Them Social Warning:%2$s Your php version is %1$s%3$s%2$s. You need to be running at least %1$s5.3%2$s or greater to use this plugin. Please upgrade the php by contacting your host provider. Some host providers will allow you to change this yourself in the hosting control panel too. %4$s If you are hosting with BlueHost or Godaddy and the php version above is saying you are running %1$s5.2.17%2$s but you are really running something higher please %5$sclick here for the fix%6$s. If you cannot get it to work using the method described in the link please contact your host provider and explain the problem so they can fix it.', 'feed-them-social' ),
+            esc_html__( '%1$s Feed Them Social Warning:%2$s Your php version is %1$s%3$s%2$s. You need to be running at least %1$s5.3%2$s or greater to use this plugin. Please upgrade the php by contacting your host provider. Some host providers will allow you to change this yourself in the hosting control panel too. %4$s If you are hosting with BlueHost or Godaddy and the php version above is saying you are running %1$s5.2.17%2$s but you are really running something higher please %5$sclick here for the fix%6$s. If you cannot get it to work using the method described in the link please contact your host provider and explain the problem so they can fix it.', 'feed-them-social' ),
             '<strong>',
             '</strong>',
             phpversion(),
@@ -350,7 +350,7 @@ final class Feed_Them_Social {
     public function fts_free_plugin_actions( $actions, $plugin_file, $plugin_data, $context ) {
         array_unshift(
             $actions,
-            '<a href="admin.php?page=feed-them-settings-page">' . esc_html( 'Settings', 'feed-them-social' ) . '</a> | <a href="' . esc_url( 'https://www.slickremix.com/support/', 'feed-them-social' ) . '">' . esc_html( 'Support' ) . '</a>'
+            '<a href="admin.php?page=feed-them-settings-page">' . esc_html__( 'Settings', 'feed-them-social' ) . '</a> | <a href="' . esc_url( 'https://www.slickremix.com/support/', 'feed-them-social' ) . '">' . esc_html__( 'Support', 'feed-them-social' ) . '</a>'
         );
         return $actions;
     }
@@ -367,7 +367,7 @@ final class Feed_Them_Social {
      */
     public function fts_leave_feedback_link( $links, $file ) {
         if ( plugin_basename( __FILE__ ) === $file ) {
-            $links['feedback'] = '<a href="' . esc_url( 'https://wordpress.org/support/view/plugin-reviews/feed-them-social', 'feed-them-social' ) . '" target="_blank">' . esc_html( 'Rate Plugin', 'feed-them-social' ) . '</a>';
+            $links['feedback'] = '<a href="' . esc_url( 'https://wordpress.org/support/view/plugin-reviews/feed-them-social', 'feed-them-social' ) . '" target="_blank">' . esc_html__( 'Rate Plugin', 'feed-them-social' ) . '</a>';
         }
         return $links;
     }
@@ -497,13 +497,13 @@ final class Feed_Them_Social {
                 <div class="fts_notice fts_review_notice">
                     <img src="<?php echo esc_url( plugins_url( 'feed-them-social/admin/images/feed-them-social-logo.png' ) ); ?>" alt="Feed Them Social">
                     <div class="fts-notice-text">
-                        <p><?php echo esc_html( 'It\'s great to see that you\'ve been using our Feed Them Social plugin for a while now. Hopefully you\'re happy with it!  If so, would you consider leaving a positive review? It really helps support the plugin and helps others discover it too!', 'feed-them-social' ); ?></p>
+                        <p><?php echo esc_html__( 'It\'s great to see that you\'ve been using our Feed Them Social plugin for a while now. Hopefully you\'re happy with it!  If so, would you consider leaving a positive review? It really helps support the plugin and helps others discover it too!', 'feed-them-social' ); ?></p>
                         <p class="fts-links">
-                            <a class="fts_notice_dismiss" href="<?php echo esc_url( 'https://wordpress.org/support/plugin/feed-them-social/reviews/#new-post' ); ?>" target="_blank"><?php echo esc_html( 'Sure, I\'d love to', 'feed-them-social' ); ?></a>
-                            <a class="fts_notice_dismiss" href="<?php echo esc_url( add_query_arg( 'rating_fts_slick_ignore_notice_nag', '1' ) ); ?>"><?php echo esc_html( 'I\'ve already given a review', 'feed-them-social' ); ?></a>
-                            <a class="fts_notice_dismiss" href="<?php echo esc_url( add_query_arg( 'rating_fts_slick_ignore_notice_nag', 'later' ) ); ?>"><?php echo esc_html( 'Ask me later', 'feed-them-social' ); ?></a>
-                            <a class="fts_notice_dismiss" href="<?php echo esc_url( 'https://wordpress.org/support/plugin/feed-them-social/reviews/#new-post' ); ?>" target="_blank"><?php echo esc_html( 'Not working, I need support', 'feed-them-social' ); ?></a>
-                            <a class="fts_notice_dismiss" href="<?php echo esc_url( add_query_arg( 'rating_fts_slick_ignore_notice_nag', '1' ) ); ?>"><?php echo esc_html( 'No thanks', 'feed-them-social' ); ?></a>
+                            <a class="fts_notice_dismiss" href="<?php echo esc_url( 'https://wordpress.org/support/plugin/feed-them-social/reviews/#new-post' ); ?>" target="_blank"><?php echo esc_html__( 'Sure, I\'d love to', 'feed-them-social' ); ?></a>
+                            <a class="fts_notice_dismiss" href="<?php echo esc_url( add_query_arg( 'rating_fts_slick_ignore_notice_nag', '1' ) ); ?>"><?php echo esc_html__( 'I\'ve already given a review', 'feed-them-social' ); ?></a>
+                            <a class="fts_notice_dismiss" href="<?php echo esc_url( add_query_arg( 'rating_fts_slick_ignore_notice_nag', 'later' ) ); ?>"><?php echo esc_html__( 'Ask me later', 'feed-them-social' ); ?></a>
+                            <a class="fts_notice_dismiss" href="<?php echo esc_url( 'https://wordpress.org/support/plugin/feed-them-social/reviews/#new-post' ); ?>" target="_blank"><?php echo esc_html__( 'Not working, I need support', 'feed-them-social' ); ?></a>
+                            <a class="fts_notice_dismiss" href="<?php echo esc_url( add_query_arg( 'rating_fts_slick_ignore_notice_nag', '1' ) ); ?>"><?php echo esc_html__( 'No thanks', 'feed-them-social' ); ?></a>
                         </p>
                     </div>
                 </div>

--- a/feeds/facebook/class-fts-facebook-feed-post-types.php
+++ b/feeds/facebook/class-fts-facebook-feed-post-types.php
@@ -388,7 +388,7 @@ class FTS_Facebook_Feed_Post_Types extends FTS_Facebook_Feed {
 					// $trimmed_content CANNOT be esc at this time.
 					echo ! empty( $trimmed_content ) ? $trimmed_content : '';
 					// The Popup.
-					// echo $fb_shortcode['popup'] == 'yes' ? '<div class="fts-fb-caption"><a href="' . $fb_link . '" class="fts-view-on-facebook-link" target="_blank">' . esc_html('View on Facebook', 'feed-them-facebook') . '</a></div> ' : '';.
+					// echo $fb_shortcode['popup'] == 'yes' ? '<div class="fts-fb-caption"><a href="' . $fb_link . '" class="fts-view-on-facebook-link" target="_blank">' . esc_html__('View on Facebook', 'feed-them-social') . '</a></div> ' : '';.
 					echo '<div class="fts-clear"></div></div> ';
 
 				} elseif ( 'top' !== $show_media ) {
@@ -441,7 +441,7 @@ class FTS_Facebook_Feed_Post_Types extends FTS_Facebook_Feed {
 
 								$hide_all_but_one_link = ! $isFirst ? 'style="display:none"' : '';
 
-								echo '<a href="' . esc_url( $fb_album_additional_pic->images[0]->source ) . '" class="fts-view-album-photos-large data-fb-album-photo-description" target="_blank" rel="noreferrer"  ' . $hide_all_but_one_link . '>' . esc_html( 'View Album', 'feed-them-social' ) . '</a>';
+								echo '<a href="' . esc_url( $fb_album_additional_pic->images[0]->source ) . '" class="fts-view-album-photos-large data-fb-album-photo-description" target="_blank" rel="noreferrer"  ' . $hide_all_but_one_link . '>' . esc_html__( 'View Album', 'feed-them-social' ) . '</a>';
 								echo '<div class="fts-fb-album-additional-pics-description-wrap">';
 									echo '<div class="fts-jal-fb-description-wrap fts-fb-album-description-content fts-jal-fb-description-popup">';
 
@@ -466,8 +466,8 @@ class FTS_Facebook_Feed_Post_Types extends FTS_Facebook_Feed {
 							// $fb_name ? $this->fts_facebook_post_desc( $fb_name, $fb_shortcode, $fb_type, null, $fb_by ) : '';
 							// Albums Photo Count.
 							$fb_name ? $this->fts_facebook_post_desc( $fb_name, $fb_shortcode, $fb_type, null, $fb_by ) : '';
-							$view_additional_album_photos = '24' == $key ? '. <a href="' . $fb_link . '" target="_blank" rel="noreferrer">' . esc_html( 'View more for this Album', 'feed-them-social' ) . '</a>' : '';
-							echo $fb_album_photo_count ? ' ' . esc_html( $key + 1 ) . ' ' . esc_html( 'of', 'feed-them-social' ) . ' ' . esc_html( $fb_album_photo_count ) . ' ' . esc_html( 'Photos', 'feed-them-social' ) . ' ' . $view_additional_album_photos : '';
+							$view_additional_album_photos = '24' == $key ? '. <a href="' . $fb_link . '" target="_blank" rel="noreferrer">' . esc_html__( 'View more for this Album', 'feed-them-social' ) . '</a>' : '';
+							echo $fb_album_photo_count ? ' ' . esc_html( $key + 1 ) . ' ' . esc_html__( 'of', 'feed-them-social' ) . ' ' . esc_html( $fb_album_photo_count ) . ' ' . esc_html__( 'Photos', 'feed-them-social' ) . ' ' . $view_additional_album_photos : '';
 							echo '<br/><br/>';
 
 										$fb_album_additional_pic_name = isset( $fb_album_additional_pic->name ) ? $fb_album_additional_pic->name : '';
@@ -484,14 +484,14 @@ class FTS_Facebook_Feed_Post_Types extends FTS_Facebook_Feed {
 
 						// Album Photos.
 						'album_photos' === $fb_shortcode['type'] && ( isset( $fb_shortcode['video_album'] ) && 'yes' !== $fb_shortcode['video_album'] || ! isset( $fb_shortcode['video_album'] ) ) ) {
-						echo '<a href="' . esc_url( $fb_album_picture ) . '" class="fts-view-album-photos-large" target="_blank" rel="noreferrer">' . esc_html( 'View Photo', 'feed-them-social' ) . '</a></div>';
+						echo '<a href="' . esc_url( $fb_album_picture ) . '" class="fts-view-album-photos-large" target="_blank" rel="noreferrer">' . esc_html__( 'View Photo', 'feed-them-social' ) . '</a></div>';
 
 					} elseif (
 						// Video Albums.
 						isset( $fb_shortcode['video_album'] ) && 'yes' === $fb_shortcode['video_album'] ) {
 						if ( 'yes' !== $fb_shortcode['play_btn'] ) {
 
-							echo '<a href="' . esc_url( $embed_html ) . '"  data-poster="' . esc_url( $video_photo ) . '" id="fts-view-vid1-' . esc_attr( $fts_dynamic_vid_name_string ) . '" class="fts-jal-fb-vid-html5video ' . esc_attr( $fts_view_fb_videos_btn ) . ' fts-view-fb-videos-large fts-view-fb-videos-btn fb-video-popup-' . esc_attr( $fts_dynamic_vid_name_string ) . '">' . esc_html( 'View Video', 'feed-them-social' ) . '</a>';
+							echo '<a href="' . esc_url( $embed_html ) . '"  data-poster="' . esc_url( $video_photo ) . '" id="fts-view-vid1-' . esc_attr( $fts_dynamic_vid_name_string ) . '" class="fts-jal-fb-vid-html5video ' . esc_attr( $fts_view_fb_videos_btn ) . ' fts-view-fb-videos-large fts-view-fb-videos-btn fb-video-popup-' . esc_attr( $fts_dynamic_vid_name_string ) . '">' . esc_html__( 'View Video', 'feed-them-social' ) . '</a>';
 
 							echo '<div class="fts-fb-embed-iframe-check-used-for-popup fts-fb-embed-yes">';
 							if ( $embed_height >= $embed_width ) {
@@ -502,7 +502,7 @@ class FTS_Facebook_Feed_Post_Types extends FTS_Facebook_Feed {
 						echo '</div>';
 					} else {
 						// photos.
-						echo '<a href="' . esc_url( $post_data->source ) . '" class="fts-view-album-photos-large" target="_blank" rel="noreferrer">' . esc_html( 'View Photo', 'feed-them-social' ) . '</a></div>';
+						echo '<a href="' . esc_url( $post_data->source ) . '" class="fts-view-album-photos-large" target="_blank" rel="noreferrer">' . esc_html__( 'View Photo', 'feed-them-social' ) . '</a></div>';
 					}
 
 					// echo '<div class="fts-fb-caption"><a class="view-on-facebook-albums-link" href="' . $fb_link . '" target="_blank">' . esc_html('View on Facebook', 'feed-them-social') . '</a></div>';.

--- a/feeds/instagram/class-fts-instagram-feed.php
+++ b/feeds/instagram/class-fts-instagram-feed.php
@@ -263,7 +263,7 @@ class FTS_Instagram_Feed extends feed_them_social_functions {
 	 * @since 1.9.6
 	 */
 	public function fts_view_on_instagram_link( $post_data ) {
-		return '<a href="' . esc_url( $this->fts_view_on_instagram_url( $post_data ) ) . '" class="fts-view-on-instagram-link" target="_blank" rel="noreferrer">' . esc_html( 'View on Instagram', 'feed-them-social' ) . '</a>';
+		return '<a href="' . esc_url( $this->fts_view_on_instagram_url( $post_data ) ) . '" class="fts-view-on-instagram-link" target="_blank" rel="noreferrer">' . esc_html__( 'View on Instagram', 'feed-them-social' ) . '</a>';
 	}
 
 	/**
@@ -598,23 +598,23 @@ class FTS_Instagram_Feed extends feed_them_social_functions {
 				if ( false !== $this->fts_check_feed_cache_exists( $cache ) && ! isset( $_GET['load_more_ajaxing'] ) && 'user' !== $type ) {
 					$response   = $this->fts_get_feed_cache( $cache );
 					$insta_data = isset( $type ) && 'basic' === $type || 'business' === $type ? $insta_fb_data : json_decode( $response['data'] );
-					$note       = esc_html( 'Cached', 'feed-them-social' );
+					$note       = esc_html__( 'Cached', 'feed-them-social' );
 
 				} elseif ( isset( $error_check->error_message ) || isset( $error_check->meta->error_message ) || empty( $error_check ) || 'user' === $type || !isset( $type )  ) {
 					// If the Instagram API array returns any error messages we check for them here and return the corresponding error message!
 					if ( current_user_can( 'administrator' ) ) {
 
 						if ( 'user' === $type || !isset( $type )  ) {
-                                $error = esc_html( 'The Legacy API is depreciated as of March 31st, 2020 in favor of the new Instagram Graph API and the Instagram Basic Display API. Please go to the instagram Options page of our plugin and reconnect your account and generate a new shortcode and replace your existing one.', 'feed-them-social' );
+                                $error = esc_html__( 'The Legacy API is depreciated as of March 31st, 2020 in favor of the new Instagram Graph API and the Instagram Basic Display API. Please go to the instagram Options page of our plugin and reconnect your account and generate a new shortcode and replace your existing one.', 'feed-them-social' );
 						} elseif ( isset( $error_check->error_message ) ) {
 							$error = $error_check->error_message;
 						} elseif ( isset( $error_check->meta->error_message ) ) {
 							$error = $error_check->meta->error_message;
 						} else {
-							$error = esc_html( 'Please go to the Feed Them > Instagram Options page of our Feed Them Social plugin a double check your Instagram ID matches the one used in your shortcode on this page.', 'feed-them-social' );
+							$error = esc_html__( 'Please go to the Feed Them > Instagram Options page of our Feed Them Social plugin a double check your Instagram ID matches the one used in your shortcode on this page.', 'feed-them-social' );
 						}
 
-						return esc_html( 'Feed Them Social (Notice visible to Admin only). Instagram returned:', 'feed-them-social' ) . ' ' . $error;
+						return esc_html__( 'Feed Them Social (Notice visible to Admin only). Instagram returned:', 'feed-them-social' ) . ' ' . $error;
 					} else {
 						return;
 					}
@@ -623,7 +623,7 @@ class FTS_Instagram_Feed extends feed_them_social_functions {
 					// if Error DON'T Cache.
 					if ( ! isset( $error_check->meta->error_message ) && ! isset( $_GET['load_more_ajaxing'] ) || ! isset( $error_check->error_message ) && ! isset( $_GET['load_more_ajaxing'] ) ) {
 										$this->fts_create_feed_cache( $cache, $response );
-										$note = esc_html( 'Not Cached', 'feed-them-social' );
+										$note = esc_html__( 'Not Cached', 'feed-them-social' );
 					}
 				}
 			}

--- a/feeds/twitter/class-fts-twitter-feed.php
+++ b/feeds/twitter/class-fts-twitter-feed.php
@@ -544,7 +544,7 @@ class FTS_Twitter_Feed extends feed_them_social_functions {
 
 			// IS RATE LIMIT REACHED?
 			if ( isset( $fetched_tweets->errors ) && '32' !== $fetched_tweets->errors[0]->code && '34' !== $fetched_tweets->errors[0]->code ) {
-				echo esc_html( 'Rate Limited Exceeded. Please go to the Feed Them Social Plugin then the Twitter Options page for Feed Them Social and follow the instructions under the header Twitter API Token.', 'feed-them-social' );
+				echo esc_html__( 'Rate Limited Exceeded. Please go to the Feed Them Social Plugin then the Twitter Options page for Feed Them Social and follow the instructions under the header Twitter API Token.', 'feed-them-social' );
 			}
 			// Did the fetch fail?
 			if ( isset( $error_check ) ) {
@@ -635,16 +635,16 @@ class FTS_Twitter_Feed extends feed_them_social_functions {
 
 						// option to allow the followers plus count to show.
 						if ( isset( $twitter_show_follow_count ) && 'yes' === $twitter_show_follow_count && empty( $search ) && isset( $stats_bar ) && 'yes' !== $stats_bar ) {
-							echo '<div class="twitter-followers-fts-singular"><a href="' . esc_url( $user_permalink ) . '" target="_blank">' . esc_html( 'Followers:', 'feed-them-social' ) . '</a> ' . esc_html( $followers_count ) . '</div>';
+							echo '<div class="twitter-followers-fts-singular"><a href="' . esc_url( $user_permalink ) . '" target="_blank">' . esc_html__( 'Followers:', 'feed-them-social' ) . '</a> ' . esc_html( $followers_count ) . '</div>';
 						}
 						if ( isset( $stats_bar ) && 'yes' === $stats_bar && empty( $search ) ) {
 
 							// option to allow the followers plus count to show.
 							echo '<div class="fts-twitter-followers-wrap">';
-							echo '<div class="twitter-followers-fts fts-tweets-first"><a href="' . esc_url( $user_permalink ) . '" target="_blank">' . esc_html( 'Tweets', 'feed-them-social' ) . '</a> ' . esc_html( $statuses_count ) . '</div>';
-							echo '<div class="twitter-followers-fts fts-following-link-div"><a href="' . esc_url( $user_permalink ) . '" target="_blank">' . esc_html( 'Following', 'feed-them-social' ) . '</a> ' . number_format( (float) $friends_count ) . '</div>';
-							echo '<div class="twitter-followers-fts fts-followers-link-div"><a href="' . esc_url( $user_permalink ) . '" target="_blank">' . esc_html( 'Followers', 'feed-them-social' ) . '</a> ' . esc_html( $followers_count ) . '</div>';
-							echo '<div class="twitter-followers-fts fts-likes-link-div"><a href="' . esc_url( $user_permalink ) . '" target="_blank">' . esc_html( 'Likes', 'feed-them-social' ) . '</a> ' . number_format( (float) $favourites_count ) . '</div>';
+							echo '<div class="twitter-followers-fts fts-tweets-first"><a href="' . esc_url( $user_permalink ) . '" target="_blank">' . esc_html__( 'Tweets', 'feed-them-social' ) . '</a> ' . esc_html( $statuses_count ) . '</div>';
+							echo '<div class="twitter-followers-fts fts-following-link-div"><a href="' . esc_url( $user_permalink ) . '" target="_blank">' . esc_html__( 'Following', 'feed-them-social' ) . '</a> ' . number_format( (float) $friends_count ) . '</div>';
+							echo '<div class="twitter-followers-fts fts-followers-link-div"><a href="' . esc_url( $user_permalink ) . '" target="_blank">' . esc_html__( 'Followers', 'feed-them-social' ) . '</a> ' . esc_html( $followers_count ) . '</div>';
+							echo '<div class="twitter-followers-fts fts-likes-link-div"><a href="' . esc_url( $user_permalink ) . '" target="_blank">' . esc_html__( 'Likes', 'feed-them-social' ) . '</a> ' . number_format( (float) $favourites_count ) . '</div>';
 							echo '</div>';
 
 						}

--- a/feeds/youtube/class-youtube-feed-free.php
+++ b/feeds/youtube/class-youtube-feed-free.php
@@ -419,7 +419,7 @@ class FTS_Youtube_Feed_Free extends feed_them_social_functions {
 						$this->fts_youtube_single_video_info( $video_id_or_link, $youtube_api_key_or_token, $youtube_access_token_new );
 
 						echo $fts_functions_class->fts_share_option( isset( $youtube_video_url ) ? $youtube_video_url : null, isset( $youtube_title ) ? $youtube_title : null );
-						echo '<a href="' . esc_url( $youtube_video_url ) . '" target="_blank" class="fts-jal-fb-see-more">' . esc_html( 'View on YouTube', 'feed-them-premium' ) . '</a>';
+						echo '<a href="' . esc_url( $youtube_video_url ) . '" target="_blank" class="fts-jal-fb-see-more">' . esc_html__( 'View on YouTube', 'feed-them-premium' ) . '</a>';
 						if ( '0' !== $comments_count && is_plugin_active( 'feed-them-premium/feed-them-premium.php' ) ) {
 							$this->fts_youtube_commentThreads( $video_id_or_link, $youtube_api_key_or_token, $comments_count );
 						}
@@ -508,7 +508,7 @@ class FTS_Youtube_Feed_Free extends feed_them_social_functions {
 										)
 									) . '</div>';
 									echo $fts_functions_class->fts_share_option( isset( $youtube_video_url ) ? $youtube_video_url : null, isset( $youtube_title ) ? $youtube_title : null );
-									echo '<a href="' . esc_url( $youtube_video_url ) . '" target="_blank" class="fts-jal-fb-see-more">' . esc_html( 'View on YouTube', 'feed-them-premium' ) . '</a>';
+									echo '<a href="' . esc_url( $youtube_video_url ) . '" target="_blank" class="fts-jal-fb-see-more">' . esc_html__( 'View on YouTube', 'feed-them-premium' ) . '</a>';
 									if ( isset( $comments_count ) && '0' !== $comments_count && is_plugin_active( 'feed-them-premium/feed-them-premium.php' ) ) {
 										$this->fts_youtube_commentThreads( $video_id, $youtube_api_key_or_token, $comments_count );
 									}
@@ -544,7 +544,7 @@ class FTS_Youtube_Feed_Free extends feed_them_social_functions {
 										)
 									) . '</div>';
 									echo $fts_functions_class->fts_share_option( isset( $youtube_video_url ) ? $youtube_video_url : null, isset( $youtube_title ) ? $youtube_title : null );
-									echo '<a href="' . esc_url( $youtube_video_url ) . '" target="_blank" class="fts-jal-fb-see-more">' . esc_html( 'View on YouTube', 'feed-them-premium' ) . '</a>';
+									echo '<a href="' . esc_url( $youtube_video_url ) . '" target="_blank" class="fts-jal-fb-see-more">' . esc_html__( 'View on YouTube', 'feed-them-premium' ) . '</a>';
 									if ( isset( $comments_count ) && '0' !== $comments_count && is_plugin_active( 'feed-them-premium/feed-them-premium.php' ) ) {
 										$this->fts_youtube_commentThreads( $video_id, $youtube_api_key_or_token, $comments_count );
 									}

--- a/includes/feed-them-functions.php
+++ b/includes/feed-them-functions.php
@@ -141,7 +141,7 @@ class feed_them_social_functions {
 
 		if ( wp_verify_nonce( $fts_refresh_token_nonce, 'access_token' ) ) {
 
-			$auth_obj  = $_GET['access_token'];
+			$auth_obj  = $_GET['code'];
 			$feed_type = $_GET['feed_type'];
 			$user_id   = $_GET['user_id'];
 
@@ -162,7 +162,7 @@ class feed_them_social_functions {
 							url: ftsAjax.ajaxurl,
 							success: function (response) {
 								<?php
-								$auth_obj = $_GET['access_token'];
+								$auth_obj = $_GET['code'];
 								if ( 'instagram_basic' === $feed_type ) {
 									$insta_url = esc_url_raw( 'https://graph.instagram.com/me?fields=id,username&access_token=' . $auth_obj );
 								} else {
@@ -180,7 +180,7 @@ class feed_them_social_functions {
 								}
 								if ( ! isset( $test_app_token_response->meta->error_message ) && ! isset( $test_app_token_response->error_message ) || isset( $test_app_token_response->meta->error_message ) && 'This client has not been approved to access this resource.' === $test_app_token_response->meta->error_message ) {
 									$fts_instagram_message = sprintf(
-										esc_html( '%1$sYour access token is working! Generate your shortcode on the %2$sSettings Page%3$s', 'feed-them-social' ),
+										esc_html__( '%1$sYour access token is working! Generate your shortcode on the %2$sSettings Page%3$s', 'feed-them-social' ),
 										'<div class="fts-successful-api-token">',
 										'<a href="' . esc_url( 'admin.php?page=feed-them-settings-page' . $custom_instagram_link_hash ) . '">',
 										'</a></div>'
@@ -195,7 +195,7 @@ class feed_them_social_functions {
 								} elseif ( isset( $test_app_token_response->meta->error_message ) || isset( $test_app_token_response->error_message ) ) {
 									$text                  = isset( $test_app_token_response->meta->error_message ) ? $test_app_token_response->meta->error_message : $test_app_token_response->error_message;
 									$fts_instagram_message = sprintf(
-										esc_html( '%1$sOh No something\'s wrong. %2$s. Please try clicking the button again to get a new access token. If you need additional assistance please email us at support@slickremix.com %3$s.', 'feed-them-social' ),
+										esc_html__( '%1$sOh No something\'s wrong. %2$s. Please try clicking the button again to get a new access token. If you need additional assistance please email us at support@slickremix.com %3$s.', 'feed-them-social' ),
 										'<div class="fts-failed-api-token">',
 										esc_html( $text ),
 										'</div>'
@@ -260,7 +260,7 @@ class feed_them_social_functions {
 
 			// The share wrap and links
 			$output  = '<div class="fts-share-wrap">';
-			$output .= '<a href="javascript:;" class="ft-gallery-link-popup" title="' . esc_html( 'Social Share Options', 'feed-them-social' ) . '">' . esc_html( '', 'feed-them-social' ) . '</a>';
+			$output .= '<a href="javascript:;" class="ft-gallery-link-popup" title="' . esc_html__( 'Social Share Options', 'feed-them-social' ) . '">' . esc_html( '', 'feed-them-social' ) . '</a>';
 			$output .= '<div class="ft-gallery-share-wrap">';
 			$output .= '<a href="' . esc_attr( $ft_gallery_share_facebook ) . '" target="_blank" rel="noreferrer" class="ft-galleryfacebook-icon" title="Share this post on Facebook"><i class="fa fa-facebook-square"></i></a>';
 			$output .= '<a href="' . esc_attr( $ft_gallery_share_twitter ) . '" target="_blank" rel="noreferrer" class="ft-gallerytwitter-icon" title="Share this post on Twitter"><i class="fa fa-twitter"></i></a>';
@@ -294,7 +294,7 @@ class feed_them_social_functions {
 			ob_start();
 
 			if ( ! isset( $_GET['locations'] ) ) {
-				$fb_url                     = 'fts-facebook-feed-styles-submenu-page' == $_GET['page'] ? wp_remote_fopen( 'https://graph.facebook.com/me/accounts?fields=locations{name,id,page_username,locations,store_number,store_location_descriptor,access_token},name,id,link,access_token&access_token=' . $_GET['access_token'] . '&limit=25' ) : wp_remote_fopen( 'https://graph.facebook.com/me/accounts?fields=instagram_business_account{id,username,profile_picture_url},locations{instagram_business_account{profile_picture_url,id,username},name,id,page_username,locations,store_number,store_location_descriptor,access_token},name,id,link,access_token&access_token=' . $_GET['access_token'] . '&limit=25' );
+				$fb_url                     = 'fts-facebook-feed-styles-submenu-page' == $_GET['page'] ? wp_remote_fopen( 'https://graph.facebook.com/me/accounts?fields=locations{name,id,page_username,locations,store_number,store_location_descriptor,access_token},name,id,link,access_token&access_token=' . $_GET['code'] . '&limit=25' ) : wp_remote_fopen( 'https://graph.facebook.com/me/accounts?fields=instagram_business_account{id,username,profile_picture_url},locations{instagram_business_account{profile_picture_url,id,username},name,id,page_username,locations,store_number,store_location_descriptor,access_token},name,id,link,access_token&access_token=' . $_GET['code'] . '&limit=25' );
 				$fb_token_response          = isset( $_REQUEST['next_url'] ) ? wp_remote_fopen( esc_url_raw( $_REQUEST['next_url'] ) ) : $fb_url;
 				$test_fb_app_token_response = json_decode( $fb_token_response );
 				$_REQUEST['next_url']       = isset( $test_fb_app_token_response->paging->next ) ? esc_url_raw( $test_fb_app_token_response->paging->next ) : '';
@@ -324,7 +324,7 @@ class feed_them_social_functions {
 				$reviews_token = isset( $_GET['reviews_token'] ) ? 'yes' : 'no';
 				?>
 			<div id="fb-list-wrap">
-				<div class="fts-pages-info"> <?php echo esc_html( 'Click on a page in the list below and it will add the Page ID and Access Token above, then click save.', 'feed-them-social' ); ?></div>
+				<div class="fts-pages-info"> <?php echo esc_html__( 'Click on a page in the list below and it will add the Page ID and Access Token above, then click save.', 'feed-them-social' ); ?></div>
 				<ul class="fb-page-list fb-page-master-list">
 					<?php
 			} //End make sure it's not ajaxing!
@@ -352,7 +352,7 @@ class feed_them_social_functions {
 									</span></div>
 								<div class="fb-other-wrap">
 									<small>
-								<?php echo esc_html( 'ID: ', 'feed-them-social' ); ?>
+								<?php echo esc_html__( 'ID: ', 'feed-them-social' ); ?>
 										<span class="fts-api-facebook-id"><?php echo esc_html( $data_id ); ?></span>
 								<?php echo isset( $data->store_number ) ? esc_html( '| Location: ' . $data->store_number, 'feed-them-social' ) : ''; ?>
 									</small>
@@ -377,7 +377,7 @@ class feed_them_social_functions {
 							if ( isset( $data->locations->data ) ) {
 								$location_count     = count( $data->locations->data );
 								$location_plus_sign = isset( $data->locations->paging->next ) ? '+' : '';
-								$location_text      = 1 === $location_count ? esc_html( $location_count . ' ' . esc_html( 'Location for', 'feed-them-social' ) ) : esc_html( $location_count . $location_plus_sign . ' ' . esc_html( 'Locations for', 'feed-them-social' ) );
+								$location_text      = 1 === $location_count ? esc_html( $location_count . ' ' . esc_html__( 'Location for', 'feed-them-social' ) ) : esc_html( $location_count . $location_plus_sign . ' ' . esc_html__( 'Locations for', 'feed-them-social' ) );
 								// if the locations equal 3 or less we will set the location container height to auto so the scroll loadmore does not fire.
 								$location_scroll_loadmore_needed_check = $location_count <= 3 ? 'height:auto !important' : 'height: 200px !important;';
 							}
@@ -412,12 +412,12 @@ class feed_them_social_functions {
 													</span></div>
 															<div class="fb-other-wrap">
 																<small>
-																	<?php echo esc_html( 'ID: ', 'feed-them-social' ); ?>
+																	<?php echo esc_html__( 'ID: ', 'feed-them-social' ); ?>
 																	<span class="fts-api-facebook-id"><?php echo esc_html( $loc_data_id ); ?></span>
 																	<?php
 																	if ( isset( $location->store_number ) ) {
 																		print '| ';
-																		esc_html( 'Location:', 'feed-them-social' );
+																		esc_html__( 'Location:', 'feed-them-social' );
 																		print ' ' . esc_html( $location->store_number );
 																	}
 																	?>
@@ -451,7 +451,7 @@ class feed_them_social_functions {
 								<?php
 								// Make sure it's not ajaxing locations!
 								if ( ! isset( $_GET['locations'] ) && isset( $data->locations->paging->next ) ) {
-									echo '<div id="loadMore_' . esc_attr( $data_id ) . '_location" class="fts-fb-load-more" style="background:none !Important;">' . esc_html( 'Scroll to view more Locations', 'feed-them-instagram' ) . '</div>';
+									echo '<div id="loadMore_' . esc_attr( $data_id ) . '_location" class="fts-fb-load-more" style="background:none !Important;">' . esc_html__( 'Scroll to view more Locations', 'feed-them-instagram' ) . '</div>';
 								}//End Check
 
 								// Make sure it's not ajaxing locations!
@@ -945,7 +945,7 @@ class feed_them_social_functions {
 			array( $twitter_options_page, 'feed_them_twitter_options_page' )
 		);
 		// Pinterest Options Page!
-		$pinterest_options_page = new FTS_Pinterest_Options_Page();
+		/* $pinterest_options_page = new FTS_Pinterest_Options_Page();
 		add_submenu_page(
 			'feed-them-settings-page',
 			esc_html( 'Pinterest Options', 'feed-them-social' ),
@@ -953,7 +953,7 @@ class feed_them_social_functions {
 			'manage_options',
 			'fts-pinterest-feed-styles-submenu-page',
 			array( $pinterest_options_page, 'feed_them_pinterest_options_page' )
-		);
+		); */
 		// Youtube Options Page!
 		$youtube_options_page = new FTS_Youtube_Options_Page();
 		add_submenu_page(

--- a/languages/feed-them-social.pot
+++ b/languages/feed-them-social.pot
@@ -1,0 +1,3423 @@
+#, fuzzy
+msgid ""
+msgstr ""
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"Project-Id-Version: Feed Them Social - for Twitter feed, Youtube, and more\n"
+"POT-Creation-Date: 2021-01-06 16:31-0500\n"
+"PO-Revision-Date: 2021-01-06 16:28-0500\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.4.2\n"
+"X-Poedit-Basepath: ..\n"
+"X-Poedit-Flags-xgettext: --add-comments=translators:\n"
+"X-Poedit-WPHeader: feed-them.php\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-KeywordsList: __;_e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_attr__;"
+"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;_n_noop:1,2;"
+"_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
+"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-SearchPathExcluded-0: *.min.js\n"
+
+#: admin/class-fts-facebook-options-page.php:44
+msgid "Facebook Feed Options"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:47
+msgid ""
+"Change the language, color and more for your facebook feed using the options "
+"below."
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:86
+msgid "Facebook API Token"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:88
+msgid ""
+"This Facebook Access Token is for Business Pages, Photos and Videos only and "
+"is simply used to display the feed. You must be an admin of the business "
+"page to get your token. This will NOT work for personal profiles or groups. "
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:92
+#: admin/class-fts-instagram-options-page.php:119
+#: admin/class-fts-instagram-options-page.php:230
+#: admin/class-fts-pinterest-options-page.php:77
+#, php-format
+msgid "%1$sLogin and get my Access Token%2$s"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:99
+#: admin/class-fts-facebook-options-page.php:233
+#: admin/class-fts-instagram-options-page.php:125
+#: admin/class-fts-instagram-options-page.php:238
+#: admin/class-fts-pinterest-options-page.php:83
+#: admin/class-fts-twitter-options-page.php:158
+msgid "Button not working?"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:125
+msgid "Page ID"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:131
+#: admin/class-fts-instagram-options-page.php:141
+#: admin/class-fts-instagram-options-page.php:265
+#: admin/class-fts-pinterest-options-page.php:90
+msgid "Access Token Required"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:153
+#, php-format
+msgid ""
+"Your Access Token is now working! Generate your shortcode on the "
+"%1$sSettings Page%2$s"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:163
+#: admin/class-fts-facebook-options-page.php:171
+#: admin/class-fts-instagram-options-page.php:304
+#: admin/class-fts-instagram-options-page.php:312
+#, php-format
+msgid ""
+"%1$sOh No something's wrong. %2$s. Please click the button above to retrieve "
+"a new Access Token.%3$s"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:180
+#: admin/class-fts-facebook-options-page.php:189
+#: admin/class-fts-instagram-options-page.php:321
+#: admin/class-fts-instagram-options-page.php:330
+#: admin/class-fts-twitter-options-page.php:258
+#, php-format
+msgid ""
+"%1$sTo get started, please click the button above to retrieve your Access "
+"Token.%2$s"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:218
+msgid "Facebook Page Reviews Access Token"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:220
+msgid ""
+"This Facebook Access Token works for the Reviews feed only and is simply "
+"used to display the feed. You must be an admin of the page to get your token."
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:224
+#, php-format
+msgid "%1$sLogin and get my Reviews Access Token%2$s"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:237
+msgid "Page Reviews ID"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:243
+msgid "Page Reviews Access Token"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:261
+msgid ""
+"Your Page Reviews Access Token is now working! Generate your shortcode on "
+"the <a href=\"admin.php?page=feed-them-settings-"
+"page#feed_type=facebook_reviews\">settings page</a>."
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:267
+#: admin/class-fts-facebook-options-page.php:270
+msgid "Oh No something's wrong."
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:267
+#: admin/class-fts-facebook-options-page.php:270
+msgid "Please click the button above to retreive a new Access Token."
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:275
+msgid ""
+"To get started, please click the button above to retrieve your Page Reviews "
+"Access Token."
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:293
+msgid "Reviews: Style and Text Options"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:295
+msgid ""
+"The styles above still apply, these are just some extra options for the "
+"Reviews List feed."
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:300
+#, php-format
+msgid "Stars Background Color%1$sApplies to Overall Rating too.%2$s"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:315
+#, php-format
+msgid "Stars & Text Color%1$sApplies to Overall Rating too.%2$s"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:328
+msgid "Text for the word \"star\""
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:337
+msgid "Text for the word \"Recommended\""
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:346
+msgid "Text for \"See More Reviews\""
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:355
+msgid "Remove \"See More Reviews\" link"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:359
+#: admin/class-fts-facebook-options-page.php:384
+#: admin/class-fts-facebook-options-page.php:478
+#: admin/class-fts-facebook-options-page.php:521
+#: admin/class-fts-facebook-options-page.php:564
+#: admin/class-fts-facebook-options-page.php:602
+#: admin/class-fts-facebook-options-page.php:621
+#: admin/class-fts-facebook-options-page.php:640
+#: admin/class-fts-facebook-options-page.php:674
+#: admin/class-fts-facebook-options-page.php:722
+#: admin/class-fts-facebook-options-page.php:741
+#: admin/class-fts-facebook-options-page.php:1026
+#: admin/class-fts-instagram-options-page.php:386
+#: admin/class-fts-pinterest-options-page.php:159
+#: admin/class-fts-twitter-options-page.php:314
+#: admin/class-fts-twitter-options-page.php:406
+#: admin/class-fts-youtube-options-page.php:287
+msgid "Please Select Option"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:361
+#: admin/class-fts-facebook-options-page.php:386
+#: admin/class-fts-facebook-options-page.php:523
+#: admin/class-fts-facebook-options-page.php:727
+#: admin/class-fts-facebook-options-page.php:746
+#: admin/class-fts-facebook-options-page.php:1031
+msgid "yes"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:362
+#: admin/class-fts-facebook-options-page.php:387
+#: admin/class-fts-facebook-options-page.php:524
+#: admin/class-fts-facebook-options-page.php:728
+#: admin/class-fts-facebook-options-page.php:747
+#: admin/class-fts-facebook-options-page.php:1032
+#: admin/class-fts-instagram-options-page.php:373
+#: admin/class-fts-pinterest-options-page.php:147
+#: admin/class-fts-settings-page-options.php:151
+#: admin/class-fts-settings-page-options.php:265
+#: admin/class-fts-settings-page-options.php:289
+#: admin/class-fts-settings-page-options.php:335
+#: admin/class-fts-settings-page-options.php:390
+#: admin/class-fts-settings-page-options.php:518
+#: admin/class-fts-settings-page-options.php:704
+#: admin/class-fts-settings-page-options.php:804
+#: admin/class-fts-settings-page-options.php:936
+#: admin/class-fts-settings-page-options.php:1380
+#: admin/class-fts-settings-page-options.php:1435
+#: admin/class-fts-settings-page-options.php:1486
+#: admin/class-fts-settings-page-options.php:1511
+#: admin/class-fts-settings-page-options.php:1536
+#: admin/class-fts-settings-page-options.php:1641
+#: admin/class-fts-settings-page-options.php:1660
+#: admin/class-fts-settings-page-options.php:1819
+#: admin/class-fts-settings-page-options.php:1843
+#: admin/class-fts-settings-page-options.php:1871
+#: admin/class-fts-settings-page-options.php:1896
+#: admin/class-fts-settings-page-options.php:2025
+#: admin/class-fts-settings-page-options.php:2053
+#: admin/class-fts-settings-page-options.php:2086
+#: admin/class-fts-settings-page-options.php:2207
+#: admin/class-fts-settings-page-options.php:2298
+#: admin/class-fts-settings-page-options.php:2355
+#: admin/class-fts-settings-page-options.php:3078
+#: admin/class-fts-settings-page-options.php:3106
+#: admin/class-fts-settings-page-options.php:3129
+#: admin/class-fts-settings-page-options.php:3221
+#: admin/class-fts-settings-page-options.php:3263
+#: admin/class-fts-settings-page-options.php:3282
+#: admin/class-fts-settings-page-options.php:3462
+#: admin/class-fts-settings-page-options.php:4002
+#: admin/class-fts-settings-page-options.php:4024
+#: admin/class-fts-settings-page-options.php:4046
+#: admin/class-fts-settings-page-options.php:4068
+#: admin/class-fts-settings-page-options.php:4094
+#: admin/class-fts-settings-page-options.php:4122
+#: admin/class-fts-settings-page-options.php:4256
+#: admin/class-fts-settings-page-options.php:4645
+#: admin/class-fts-settings-page-options.php:4668
+#: admin/class-fts-settings-page-options.php:4692
+#: admin/class-fts-settings-page-options.php:4713
+#: admin/class-fts-settings-page-options.php:4734
+#: admin/class-fts-settings-page-options.php:4837
+#: admin/class-fts-settings-page-options.php:4927
+#: admin/class-fts-settings-page-options.php:5055
+#: admin/class-fts-twitter-options-page.php:285
+#: admin/class-fts-twitter-options-page.php:301
+#: admin/class-fts-twitter-options-page.php:341
+#: admin/class-fts-twitter-options-page.php:364
+#: admin/class-fts-twitter-options-page.php:386
+#: admin/class-fts-twitter-options-page.php:412
+#: admin/class-fts-youtube-options-page.php:271
+msgid "Yes"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:364
+#: admin/class-fts-facebook-options-page.php:389
+#: admin/class-fts-facebook-options-page.php:526
+#: admin/class-fts-facebook-options-page.php:724
+#: admin/class-fts-facebook-options-page.php:743
+#: admin/class-fts-facebook-options-page.php:1028
+msgid "no"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:365
+#: admin/class-fts-facebook-options-page.php:390
+#: admin/class-fts-facebook-options-page.php:527
+#: admin/class-fts-facebook-options-page.php:725
+#: admin/class-fts-facebook-options-page.php:744
+#: admin/class-fts-facebook-options-page.php:1029
+#: admin/class-fts-instagram-options-page.php:370
+#: admin/class-fts-pinterest-options-page.php:144
+#: admin/class-fts-settings-page-options.php:155
+#: admin/class-fts-settings-page-options.php:223
+#: admin/class-fts-settings-page-options.php:269
+#: admin/class-fts-settings-page-options.php:293
+#: admin/class-fts-settings-page-options.php:331
+#: admin/class-fts-settings-page-options.php:386
+#: admin/class-fts-settings-page-options.php:514
+#: admin/class-fts-settings-page-options.php:700
+#: admin/class-fts-settings-page-options.php:800
+#: admin/class-fts-settings-page-options.php:932
+#: admin/class-fts-settings-page-options.php:1384
+#: admin/class-fts-settings-page-options.php:1439
+#: admin/class-fts-settings-page-options.php:1490
+#: admin/class-fts-settings-page-options.php:1515
+#: admin/class-fts-settings-page-options.php:1540
+#: admin/class-fts-settings-page-options.php:1637
+#: admin/class-fts-settings-page-options.php:1664
+#: admin/class-fts-settings-page-options.php:1823
+#: admin/class-fts-settings-page-options.php:1847
+#: admin/class-fts-settings-page-options.php:1867
+#: admin/class-fts-settings-page-options.php:1900
+#: admin/class-fts-settings-page-options.php:2021
+#: admin/class-fts-settings-page-options.php:2049
+#: admin/class-fts-settings-page-options.php:2082
+#: admin/class-fts-settings-page-options.php:2203
+#: admin/class-fts-settings-page-options.php:2294
+#: admin/class-fts-settings-page-options.php:2351
+#: admin/class-fts-settings-page-options.php:3082
+#: admin/class-fts-settings-page-options.php:3102
+#: admin/class-fts-settings-page-options.php:3125
+#: admin/class-fts-settings-page-options.php:3217
+#: admin/class-fts-settings-page-options.php:3259
+#: admin/class-fts-settings-page-options.php:3286
+#: admin/class-fts-settings-page-options.php:3458
+#: admin/class-fts-settings-page-options.php:3998
+#: admin/class-fts-settings-page-options.php:4020
+#: admin/class-fts-settings-page-options.php:4042
+#: admin/class-fts-settings-page-options.php:4064
+#: admin/class-fts-settings-page-options.php:4090
+#: admin/class-fts-settings-page-options.php:4118
+#: admin/class-fts-settings-page-options.php:4252
+#: admin/class-fts-settings-page-options.php:4641
+#: admin/class-fts-settings-page-options.php:4664
+#: admin/class-fts-settings-page-options.php:4688
+#: admin/class-fts-settings-page-options.php:4709
+#: admin/class-fts-settings-page-options.php:4730
+#: admin/class-fts-settings-page-options.php:4833
+#: admin/class-fts-settings-page-options.php:4923
+#: admin/class-fts-settings-page-options.php:5051
+#: admin/class-fts-twitter-options-page.php:282
+#: admin/class-fts-twitter-options-page.php:298
+#: admin/class-fts-twitter-options-page.php:338
+#: admin/class-fts-twitter-options-page.php:361
+#: admin/class-fts-twitter-options-page.php:383
+#: admin/class-fts-twitter-options-page.php:409
+#: admin/class-fts-youtube-options-page.php:275
+msgid "No"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:374
+msgid "Reviews: Overall Rating Style Options"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:376
+msgid "These styles are for the overall rating that appear above your feed."
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:380
+msgid "Hide Overall Rating Background & Border"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:399
+msgid "Overall Rating Background Color"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:408
+msgid "Overall Rating Text Color"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:417
+msgid "Overall Rating Border Color"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:426
+msgid "Overall Rating Background Padding"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:435
+msgid "Overall Rating \"of 5 stars\" text"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:444
+msgid "Overall Rating \"reviews\" text"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:458
+msgid "Language Options"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:463
+#, php-format
+msgid ""
+"You must have your Facebook Access Token saved above before this feature "
+"will work. This option will translate the FB Titles and Like Button or Box "
+"Text. It will not translate your actual post. To translate the Feed Them "
+"Social parts of this plugin just set your language on the %1$sWordPress "
+"settings%2$s page. If would like to help translate please %3$sClick Here.%4$s"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:474
+msgid "Language For Facebook Feeds"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:495
+msgid "Offset Limit"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:499
+#, php-format
+msgid ""
+"%1$sWARNING, PLEASE READ CAREFULLY!%2$s DO NOT use this field to set your "
+"facebook posts. If you are getting the message \"Please go to the Facebook "
+"Options page of our plugin and look for the \"Change Limit\" option and add "
+"the number 7 or more.\" then adjust the number below so posts will show in "
+"your feed. Generally adding at least %3$s7%4$s is a good idea if you are "
+"getting that notice. This is only for Pages and Groups. We filter certain "
+"posts that do not have a story or message or if the shared content is not "
+"available via the API."
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:508
+msgid "Offset Quantity"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:517
+msgid "Hide Notice on Front End"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:538
+#: feeds/facebook/class-fts-facebook-feed.php:1338
+msgid "View on Facebook"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:554
+msgid "Like Button or Box Options"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:556
+#: admin/class-fts-pinterest-options-page.php:138
+#: admin/class-fts-twitter-options-page.php:275
+msgid "This will only show on regular feeds not combined feeds."
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:559
+#: admin/class-fts-instagram-options-page.php:366
+#: admin/class-fts-pinterest-options-page.php:140
+#: admin/class-fts-twitter-options-page.php:294
+#: admin/class-fts-youtube-options-page.php:264
+msgid "Show Follow Button"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:566
+msgid "dont-display"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:567
+msgid "Don't Display a Button"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:570
+msgid "like-box"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:571
+#: admin/class-fts-settings-page-options.php:1888
+msgid "Like Box"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:573
+msgid "like-box-faces"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:574
+msgid "Like Box with Faces"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:578
+msgid "like-button"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:579
+msgid "Like Button"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:581
+msgid "like-button-share"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:582
+msgid "Like Button and Share Button"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:584
+msgid "like-button-faces"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:585
+msgid "Like Button with Faces"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:587
+msgid "like-button-share-faces"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:588
+msgid "Like Button and Share Button with Faces"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:598
+msgid "Show Profile Icon next to social option above"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:604
+msgid "fb_like_box_cover-yes"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:605
+msgid "Display Cover Photo in Like Box"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:607
+msgid "fb_like_box_cover-no"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:608
+msgid "Hide Cover Photo in Like Box"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:617
+msgid "Like Button Color"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:623
+msgid "light"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:624
+msgid "Light"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:626
+msgid "dark"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:627
+msgid "Dark"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:636
+msgid "Placement of the Button(s)"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:642
+msgid "fb-like-top-above-title"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:643
+msgid "Show Top of Feed Above Title"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:645
+msgid "fb-like-top-below-title"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:646
+msgid "Show Top of Feed Below Title"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:648
+msgid "fb-like-below"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:649
+msgid "Show Botton of Feed"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:659
+msgid "Global Facebook Style Options"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:666
+#, php-format
+msgid "Page Title Tag %1$s %2$s"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:676
+msgid "h1"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:677
+msgid "h1 (Default)"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:679
+#: admin/class-fts-facebook-options-page.php:680
+msgid "h2"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:682
+#: admin/class-fts-facebook-options-page.php:683
+msgid "h3"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:685
+#: admin/class-fts-facebook-options-page.php:686
+msgid "h4"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:688
+#: admin/class-fts-facebook-options-page.php:689
+msgid "h5"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:691
+#: admin/class-fts-facebook-options-page.php:692
+msgid "h6"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:701
+msgid "Page Title Size"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:737
+#: admin/class-fts-twitter-options-page.php:402
+msgid "Hide Images in Posts"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:756
+msgid "Max-width for Images & Videos"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:765
+msgid "Feed Header Extra Text Color"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:774
+#: admin/class-fts-twitter-options-page.php:430
+msgid "Feed Description Text Size"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:783
+#: admin/class-fts-twitter-options-page.php:439
+msgid "Feed Text Color"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:792
+#: admin/class-fts-twitter-options-page.php:448
+msgid "Feed Link Color"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:801
+#: admin/class-fts-twitter-options-page.php:457
+msgid "Feed Link Color Hover"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:810
+#: admin/class-fts-twitter-options-page.php:466
+msgid "Feed Width"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:834
+#: admin/class-fts-twitter-options-page.php:490
+msgid "Feed Padding"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:860
+msgid "Feed Background Color"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:869
+#: admin/class-fts-facebook-options-page.php:893
+msgid "Border Bottom Color"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:880
+msgid "Grid Styles"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:884
+msgid "Posts Background Color"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:903
+#: admin/class-fts-instagram-options-page.php:409
+#: admin/class-fts-youtube-options-page.php:309
+msgid "Load More Button Styles & Options"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:907
+#: admin/class-fts-youtube-options-page.php:314
+msgid "Button Color"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:916
+#: admin/class-fts-youtube-options-page.php:323
+msgid "Text Color"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:925
+#: admin/class-fts-instagram-options-page.php:432
+#: admin/class-fts-youtube-options-page.php:332
+msgid "\"Load More\" Text"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:934
+msgid "\"No More Posts\" Text"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:943
+#: admin/class-fts-instagram-options-page.php:441
+msgid "\"No More Photos\" Text"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:952
+#: admin/class-fts-youtube-options-page.php:341
+msgid "\"No More Videos\" Text"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:965
+msgid "\"No More Reviews\" Text"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:976
+msgid "Event Style Options"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:978
+msgid ""
+"The styles above still apply, these are just some extra options for the "
+"Event List feed."
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:981
+msgid "Events Feed: Title Color"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:990
+msgid "Events Feed: Title Size"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:999
+msgid "Events Feed: Map Link Color"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:1009
+msgid "Facebook Error Message"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:1022
+msgid "Hide Error Handler Message"
+msgstr ""
+
+#: admin/class-fts-facebook-options-page.php:1040
+#: admin/class-fts-instagram-options-page.php:448
+#: admin/class-fts-pinterest-options-page.php:210
+#: admin/class-fts-youtube-options-page.php:349
+msgid "Save All Changes"
+msgstr ""
+
+#: admin/class-fts-instagram-options-page.php:71
+msgid "Instagram Feed Options"
+msgstr ""
+
+#: admin/class-fts-instagram-options-page.php:74
+msgid ""
+"Get your Access Token and add a follow button and position it using the "
+"options below."
+msgstr ""
+
+#: admin/class-fts-instagram-options-page.php:91
+msgid "Instagram Basic API Token"
+msgstr ""
+
+#: admin/class-fts-instagram-options-page.php:112
+msgid ""
+"This is required to make the Instagram Feed work. Click the button below and "
+"it will connect to your Instagram Account to get an access token. It will "
+"then return to this page and save it in the inputs below. After it finishes "
+"you will be able to generate your Instagram feed. Instagram Basic "
+"connections do not allow you to show Profile info or Heart/Comment counts. "
+"Please use the Instagram Business option to achieve that."
+msgstr ""
+
+#: admin/class-fts-instagram-options-page.php:132
+#: admin/class-fts-instagram-options-page.php:259
+msgid "Instagram ID"
+msgstr ""
+
+#: admin/class-fts-instagram-options-page.php:168
+#, php-format
+msgid ""
+"%1$sThe %2$sLegacy API will be depreciated as of March 31st, 2020%3$s in "
+"favor of the new Instagram Graph API and the Instagram Basic Display API. "
+"Please click the the button above to reconnect your account or you can "
+"connect as a Business account below. You must also generate a new shortcode "
+"and replace your existing one.%4$s"
+msgstr ""
+
+#: admin/class-fts-instagram-options-page.php:177
+#: admin/class-fts-pinterest-options-page.php:106
+#: includes/feed-them-functions.php:183
+#, php-format
+msgid ""
+"%1$sYour access token is working! Generate your shortcode on the "
+"%2$sSettings Page%3$s"
+msgstr ""
+
+#: admin/class-fts-instagram-options-page.php:185
+#, php-format
+msgid ""
+"%1$sOh No something's wrong. %2$s Please try clicking the button again to "
+"get a new access token. If you need additional assistance please email us at "
+"support@slickremix.com %3$s"
+msgstr ""
+
+#: admin/class-fts-instagram-options-page.php:196
+#, php-format
+msgid "%1$sYou are required to get an access token to view your photos.%2$s"
+msgstr ""
+
+#: admin/class-fts-instagram-options-page.php:213
+msgid "Instagram Business API Token"
+msgstr ""
+
+#: admin/class-fts-instagram-options-page.php:217
+#, php-format
+msgid ""
+"You must have your Instagram Account linked to a Facebook Business Page, "
+"this is required to make the Instagram Business Feed or Hashtag Feed work. "
+"%1$sRead Instructions%2$s. Once you have completed the instructions you can "
+"click the button below and it will connect to your Facebook Account to get "
+"an access token. It should return a Facebook page or list of pages you are "
+"admin of and display which ones are connected to Instagram. Choose one, then "
+"click save. The Instagram Business option will allow you to display your "
+"profile info and the Heart/Comment counts on your media."
+msgstr ""
+
+#: admin/class-fts-instagram-options-page.php:294
+#, php-format
+msgid ""
+"Your access token is working! Generate your shortcode on the %1$sSettings "
+"Page%2$s"
+msgstr ""
+
+#: admin/class-fts-instagram-options-page.php:361
+#: admin/class-fts-pinterest-options-page.php:136
+#: admin/class-fts-twitter-options-page.php:273
+#: admin/class-fts-youtube-options-page.php:262
+msgid "Follow Button Options"
+msgstr ""
+
+#: admin/class-fts-instagram-options-page.php:363
+msgid "This will only show on regular feeds not combined or hashtag feeds."
+msgstr ""
+
+#: admin/class-fts-instagram-options-page.php:382
+#: admin/class-fts-pinterest-options-page.php:155
+#: admin/class-fts-youtube-options-page.php:283
+msgid "Placement of the Buttons"
+msgstr ""
+
+#: admin/class-fts-instagram-options-page.php:392
+#: admin/class-fts-pinterest-options-page.php:162
+#: admin/class-fts-twitter-options-page.php:317
+#: admin/class-fts-youtube-options-page.php:291
+msgid "Show Above Feed"
+msgstr ""
+
+#: admin/class-fts-instagram-options-page.php:398
+#: admin/class-fts-pinterest-options-page.php:165
+#: admin/class-fts-twitter-options-page.php:320
+#: admin/class-fts-youtube-options-page.php:296
+msgid "Show Below Feed"
+msgstr ""
+
+#: admin/class-fts-instagram-options-page.php:414
+msgid "Load More Button Color"
+msgstr ""
+
+#: admin/class-fts-instagram-options-page.php:423
+msgid "Load More Button Text Color"
+msgstr ""
+
+#: admin/class-fts-pinterest-options-page.php:42
+msgid ""
+"Without notice or warning the Pinterest API has become unavailable. Once the "
+"API is available to us again we will make an update to correct the issue. "
+"For the time being we are going to disable the access token button. 4-20-2020"
+msgstr ""
+
+#: admin/class-fts-pinterest-options-page.php:49
+msgid "Pinterest Feed Options"
+msgstr ""
+
+#: admin/class-fts-pinterest-options-page.php:52
+msgid "Add a follow button and position it using the options below."
+msgstr ""
+
+#: admin/class-fts-pinterest-options-page.php:69
+msgid "Pinterest Access Token"
+msgstr ""
+
+#: admin/class-fts-pinterest-options-page.php:72
+msgid ""
+"This is required to make the feed work. Click the button below and it will "
+"connect to your Pinterest account to get an access token, and it will return "
+"it in the input below. Then click the save button and you will now be able "
+"to generate your Pinterest feed from the Settings page of our plugin."
+msgstr ""
+
+#: admin/class-fts-pinterest-options-page.php:113
+#, php-format
+msgid ""
+"%1$sOh No something's wrong. %2$s. Please try again, if you are still having "
+"troulbes please contact us on our Support Forum. Make sure to include "
+"screenshots of the browser page that may come up with any errors. "
+"%3$sSupport Forum%4$s"
+msgstr ""
+
+#: admin/class-fts-pinterest-options-page.php:122
+#, php-format
+msgid ""
+"%1$sYou are required to get an access token to view your any of the "
+"Pinterest Feeds. Click \"Save All Changes\" after getting your Access Token."
+"%2$s"
+msgstr ""
+
+#: admin/class-fts-pinterest-options-page.php:175
+msgid "Boards List Style Options"
+msgstr ""
+
+#: admin/class-fts-pinterest-options-page.php:179
+#, php-format
+msgid "These styles are for the list of Boards type feed %1$sseen here%2$s"
+msgstr ""
+
+#: admin/class-fts-pinterest-options-page.php:186
+msgid "Board Title Color"
+msgstr ""
+
+#: admin/class-fts-pinterest-options-page.php:194
+msgid "Board Title Size"
+msgstr ""
+
+#: admin/class-fts-pinterest-options-page.php:202
+msgid "Background on Hover"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:35
+msgid "Combine Streams Shortcode Generator"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:43
+msgid "Feeds To Combine"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:56
+msgid "All Feeds"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:81
+msgid "Combined Stream"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:83
+msgid "Combined Total # of Posts"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:88
+#: admin/class-fts-settings-page-options.php:1339
+msgid "6 is the default number"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:104
+msgid "# of Posts per Social Network"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:104
+msgid "NOT the combined total"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:111
+msgid "1 is the default number"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:126
+#: admin/class-fts-settings-page-options.php:1552
+msgid "Amount of words per post"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:126
+#: admin/class-fts-settings-page-options.php:1552
+msgid "Type 0 to remove the posts description"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:130
+#: admin/class-fts-settings-page-options.php:1556
+msgid "is the default number"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:145
+msgid "Center Feed Container"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:169
+msgid "Feed Fixed Height"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:169
+#: admin/class-fts-settings-page-options.php:1354
+#: admin/class-fts-settings-page-options.php:3975
+#: admin/class-fts-settings-page-options.php:4590
+#: admin/class-fts-settings-page-options.php:4612
+msgid "Leave blank for auto height"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:175
+#: admin/class-fts-settings-page-options.php:963
+#: admin/class-fts-settings-page-options.php:987
+#: admin/class-fts-settings-page-options.php:1359
+#: admin/class-fts-settings-page-options.php:2146
+#: admin/class-fts-settings-page-options.php:2174
+#: admin/class-fts-settings-page-options.php:2236
+#: admin/class-fts-settings-page-options.php:2265
+#: admin/class-fts-settings-page-options.php:2324
+#: admin/class-fts-settings-page-options.php:3542
+#: admin/class-fts-settings-page-options.php:3563
+#: admin/class-fts-settings-page-options.php:3979
+#: admin/class-fts-settings-page-options.php:4202
+#: admin/class-fts-settings-page-options.php:4224
+#: admin/class-fts-settings-page-options.php:4284
+#: admin/class-fts-settings-page-options.php:4313
+#: admin/class-fts-settings-page-options.php:4594
+#: admin/class-fts-settings-page-options.php:4616
+#: admin/class-fts-settings-page-options.php:5007
+#: admin/class-fts-settings-page-options.php:5027
+msgid "for example"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:191
+msgid "Background Color"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:208
+msgid "Show Social Icon"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:208
+msgid "Right, Left or No"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:215
+#: admin/class-fts-settings-page-options.php:1415
+#: admin/class-fts-settings-page-options.php:1717
+#: admin/class-fts-settings-page-options.php:1971
+#: admin/class-fts-settings-page-options.php:3329
+#: admin/class-fts-settings-page-options.php:3360
+msgid "Right"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:219
+#: admin/class-fts-settings-page-options.php:1407
+#: admin/class-fts-settings-page-options.php:1709
+#: admin/class-fts-settings-page-options.php:1963
+#: admin/class-fts-settings-page-options.php:3333
+#: admin/class-fts-settings-page-options.php:3364
+msgid "Left"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:236
+#: admin/class-fts-settings-page-options.php:1453
+msgid "Show Image/Video"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:236
+msgid "Bottom (default) or Top of Post"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:243
+#: admin/class-fts-settings-page-options.php:1461
+msgid "Below Username, Date & Description"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:247
+#: admin/class-fts-settings-page-options.php:1465
+msgid "Above Username, Date & Description"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:258
+#: admin/class-fts-settings-page-options.php:1503
+msgid "Show Username"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:258
+#: admin/class-fts-settings-page-options.php:282
+#: admin/class-fts-settings-page-options.php:1374
+#: admin/class-fts-settings-page-options.php:1429
+#: admin/class-fts-settings-page-options.php:1478
+#: admin/class-fts-settings-page-options.php:1503
+#: admin/class-fts-settings-page-options.php:1528
+msgid "Yes or No"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:282
+#: admin/class-fts-settings-page-options.php:1528
+msgid "Show Date"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:306
+msgid "Padding"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:323
+msgid "Facebook"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:325
+msgid "Combine Facebook"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:355
+msgid "Facebook ID or Name"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:377
+msgid "Twitter"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:379
+msgid "Combine Twitter"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:407
+#: admin/class-fts-settings-page-options.php:1126
+#: admin/class-fts-settings-page-options.php:2830
+#: admin/class-fts-settings-page-options.php:3661
+#: admin/class-fts-settings-page-options.php:3866
+#: admin/class-fts-settings-page-options.php:4389
+msgid "Feed Type"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:420
+#: admin/class-fts-settings-page-options.php:3879
+msgid "User Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:426
+#: admin/class-fts-settings-page-options.php:3885
+msgid "Hashtag, Search and more Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:449
+#: admin/class-fts-settings-page-options.php:3897
+msgid "Twitter Search Name (required)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:472
+#: admin/class-fts-settings-page-options.php:3920
+msgid "Twitter Search"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:481
+#: admin/class-fts-settings-page-options.php:485
+#: admin/class-fts-settings-page-options.php:3929
+#: admin/class-fts-settings-page-options.php:3933
+msgid "Twitter Name"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:485
+#: admin/class-fts-settings-page-options.php:3933
+msgid "You must copy your"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:485
+#: admin/class-fts-settings-page-options.php:1220
+#: admin/class-fts-settings-page-options.php:1228
+#: admin/class-fts-settings-page-options.php:3754
+#: admin/class-fts-settings-page-options.php:3933
+msgid "and paste it in the first input below."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:506
+msgid "Instagram"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:508
+msgid "Combine Instagram"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:537
+msgid "Instagram Type"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:547
+#: admin/class-fts-settings-page-options.php:4402
+msgid "Basic Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:552
+#: admin/class-fts-settings-page-options.php:4407
+msgid "Business Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:557
+#: admin/class-fts-settings-page-options.php:4412
+msgid "Hashtag Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:600
+#: admin/class-fts-settings-page-options.php:604
+#: admin/class-fts-settings-page-options.php:4445
+msgid "Instagram ID # (required)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:614
+#: admin/class-fts-settings-page-options.php:4459
+msgid ""
+"<div class=\"fts-insta-info-plus-wrapper\">If your Access Token is set on "
+"the Instagram Options page of our plugin your ID should appear below.</div>"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:618
+msgid ""
+"<div class=\"fts-insta-info-plus-wrapper\">If your Hashtag Access Token is "
+"set on the Instagram Options page of our plugin your ID should appear below."
+"</div>"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:640
+#: admin/class-fts-settings-page-options.php:4483
+msgid "Hashtag (required)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:650
+msgid ""
+"Add your hashtag below. <strong>DO NOT</strong> add the #, just the name. "
+"Only one hashtag allowed at this time. Hashtag media only stays on Instagram "
+"for 24 hours and the API does not give us a date/time. That also means if "
+"you decide to combine this feed these media posts will appear before any "
+"other posts because we cannot sort them by date. In order to use the "
+"Instagram hashtag feed you must have your Instagram account linked to a "
+"Facebook Business Page. <a target=\"_blank\" href=\"https://www.slickremix."
+"com/docs/link-instagram-account-to-facebook/\">Read Instructions.</a>"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:668
+#: admin/class-fts-settings-page-options.php:4531
+msgid "Hashtag Search Type"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:676
+#: admin/class-fts-settings-page-options.php:4539
+msgid "Recent Media"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:680
+#: admin/class-fts-settings-page-options.php:4543
+msgid "Top Media (Most Interactions)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:692
+msgid "Pinterest"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:694
+msgid "Combine Pinterest"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:723
+msgid "Pinterest Type"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:732
+#: admin/class-fts-settings-page-options.php:3694
+msgid "Latest Pins from a User"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:738
+#: admin/class-fts-settings-page-options.php:3688
+msgid "Pins From a Specific Board"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:756
+#: admin/class-fts-settings-page-options.php:3754
+msgid "Pinterest Name"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:776
+msgid "Pinterest Board ID"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:792
+msgid "Youtube"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:794
+msgid "Combine Youtube"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:823
+msgid "Youtube Type"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:829
+#: admin/class-fts-settings-page-options.php:2851
+msgid "Channel Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:833
+#: admin/class-fts-settings-page-options.php:2857
+msgid "Channel's Specific Playlist"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:839
+#: admin/class-fts-settings-page-options.php:2863
+msgid "User's Most Recent Videos"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:845
+#: admin/class-fts-settings-page-options.php:2869
+msgid "User's Specific Playlist"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:864
+msgid "YouTube Username"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:885
+msgid "YouTube Playlist ID"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:903
+msgid "YouTube Channel ID"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:923
+#: admin/class-fts-settings-page-options.php:2194
+#: admin/class-fts-settings-page-options.php:4243
+msgid "Grid"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:926
+#: admin/class-fts-settings-page-options.php:2197
+#: admin/class-fts-settings-page-options.php:4246
+msgid "Display Posts in Grid"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:958
+#: admin/class-fts-settings-page-options.php:2231
+#: admin/class-fts-settings-page-options.php:4279
+msgid "Grid Column Width"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:962
+#: admin/class-fts-settings-page-options.php:2112
+#: admin/class-fts-settings-page-options.php:2235
+#: admin/class-fts-settings-page-options.php:3485
+#: admin/class-fts-settings-page-options.php:4145
+#: admin/class-fts-settings-page-options.php:4283
+#: admin/class-fts-settings-page-options.php:4775
+#: admin/class-fts-settings-page-options.php:4948
+msgid "NOTE:"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:962
+#: admin/class-fts-settings-page-options.php:2235
+#: admin/class-fts-settings-page-options.php:4283
+#, php-format
+msgid ""
+"Define the Width of each post and the Space between each post below. You "
+"must add px after any number. Learn how to make the %1$sgrid responsive%2$s."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:983
+#: admin/class-fts-settings-page-options.php:2261
+#: admin/class-fts-settings-page-options.php:4309
+msgid "Grid Spaces Between Posts"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1105
+msgid "Combine Streams Shortcode"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1114
+msgid "Facebook Page Shortcode Generator"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1139
+msgid "Facebook Page"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1160
+msgid "Facebook Album Photos"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1166
+msgid "Facebook Album Covers"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1172
+msgid "Facebook Videos"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1178
+msgid "Facebook Page Reviews"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1213
+msgid "Facebook ID (required)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1216
+#: admin/class-fts-settings-page-options.php:1236
+#: admin/class-fts-settings-page-options.php:1240
+#: admin/class-fts-settings-page-options.php:1244
+msgid ""
+"If your Access Token is set on the Facebook Options page of our plugin your "
+"ID should appear below."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1220
+#: admin/class-fts-settings-page-options.php:1224
+#: admin/class-fts-settings-page-options.php:1228
+#: admin/class-fts-settings-page-options.php:3728
+#: admin/class-fts-settings-page-options.php:3754
+msgid "Copy your"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1220
+msgid "Facebook Group ID"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1224
+msgid "Facebook Page ID"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1224
+msgid ""
+"and paste it in the first input below. PLEASE NOTE: This will only work with "
+"Facebook Page Events and you cannot have more than 25 events on Facebook."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1228
+msgid "Facebook Event ID"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1232
+msgid "To show a specific Album copy your"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1232
+msgid "Facebook Album ID"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1232
+msgid ""
+"and paste it in the third input below. If you want to show all your uploaded "
+"photos leave the Album ID input blank."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1264
+#: admin/class-fts-settings-page-options.php:4509
+msgid "Access Token (required) "
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1270
+#: admin/class-fts-settings-page-options.php:4515
+#: admin/class-fts-settings-page.php:101
+msgid ""
+"More than 6 Requires <a target=\"_blank\" href=\"https://www.slickremix.com/"
+"downloads/feed-them-social-premium-extension/\">Premium version</a>"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1286
+msgid "Album ID "
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1286
+msgid "Leave blank to show all uploaded photos"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1311
+msgid "Post Type Visible"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1317
+msgid "Display Posts made by Page only"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1321
+msgid "Display Posts made by Page and Others"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1334
+msgid "# of Posts"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1354
+msgid "Facebook Fixed Height"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1374
+msgid "Show Page Title"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1401
+msgid "Align Title"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1401
+msgid "Left, Center or Right"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1411
+#: admin/class-fts-settings-page-options.php:1713
+#: admin/class-fts-settings-page-options.php:1967
+msgid "Center"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1429
+msgid "Show Page Description"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1453
+msgid "Bottom or Top of Post"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1478
+msgid "Show User Thumbnail"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1573
+msgid "Facebook Image Width"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1573
+#: admin/class-fts-settings-page-options.php:1594
+msgid "Max width is 640px"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1594
+msgid "Facebook Image Height"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1612
+#: admin/class-fts-settings-page-options.php:4850
+msgid "The space between photos"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1630
+msgid "Hide Date, Likes and Comments"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1631
+#: admin/class-fts-settings-page-options.php:4887
+msgid "Good for image sizes under 120px"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1654
+msgid "Center Facebook Container"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1678
+msgid "Image Stacking Animation On"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1679
+msgid "This happens when resizing browser"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1703
+msgid "Align Images"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1736
+msgid "Reviews"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1738
+msgid "Reviews to Show"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1744
+msgid "Show all Reviews"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1748
+msgid "5 Star Reviews only"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1752
+msgid "4 and 5 Stars Reviews only"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1756
+msgid "3, 4 and 5 Star Reviews only"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1760
+msgid "2, 3, 4, and 5 Star Reviews only"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1777
+msgid "Rating Format"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1777
+msgid ""
+"8/17/2018: Facebook has moved to what are called \"recommendations\" so for "
+"some people this option may not be necessary."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1783
+msgid "5 star - &#9733;&#9733;&#9733;&#9733;&#9733;"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1787
+msgid "5 star &#9733;"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1791
+msgid "5 star"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1795
+msgid "5 &#9733;"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1799
+msgid "&#9733;&#9733;&#9733;&#9733;&#9733;"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1813
+msgid "Overall Rating above Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1813
+msgid ""
+"More settings: <a href=\"admin.php?page=fts-facebook-feed-styles-submenu-"
+"page#overall-rating-options\">Facebook Options</a> page."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1837
+msgid "Hide Reviews with no description"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1861
+msgid "Hide the text \"See More Reviews\""
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1890
+msgid "Hide Like Box or Button"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1890
+msgid ""
+"Turn on from <a href=\"admin.php?page=fts-facebook-feed-styles-submenu-page"
+"\">Facebook Options</a> page"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1923
+msgid "Position of Like Box or Button"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1929
+msgid "Above Title"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1933
+msgid "Below Title"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1937
+msgid "Bottom of Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1957
+msgid "Align Like Box or Button"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1988
+msgid "Width of Like Box"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1988
+msgid "This only works for the Like Box"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:1992
+msgid "500px max"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2013
+#: admin/class-fts-settings-page-options.php:4079
+#: admin/class-fts-settings-page-options.php:5043
+msgid "Popup"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2015
+#: includes/feed-them-functions.php:2438
+msgid "Display Photos in Popup"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2043
+msgid "Hide Comments in Popup"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2074
+#: admin/class-fts-settings-page-options.php:3450
+#: admin/class-fts-settings-page-options.php:4110
+#: admin/class-fts-settings-page-options.php:4912
+#: feeds/instagram/class-fts-instagram-feed.php:371
+#: feeds/twitter/class-fts-twitter-feed.php:329
+#: feeds/youtube/class-youtube-feed-free.php:566
+msgid "Load More"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2076
+#: admin/class-fts-settings-page-options.php:3452
+#: admin/class-fts-settings-page-options.php:4112
+msgid "Load More Button"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2108
+#: admin/class-fts-settings-page-options.php:3481
+#: admin/class-fts-settings-page-options.php:4141
+msgid "Load More Style"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2112
+#: admin/class-fts-settings-page-options.php:3485
+#: admin/class-fts-settings-page-options.php:4145
+#: admin/class-fts-settings-page-options.php:4948
+msgid ""
+"The Button option will show a \"Load More Posts\" button under your feed. "
+"The AutoScroll option will load more posts when you reach the bottom of the "
+"feed. AutoScroll ONLY works if you've filled in a Fixed Height for your feed."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2115
+#: admin/class-fts-settings-page-options.php:3488
+#: admin/class-fts-settings-page-options.php:4148
+#: admin/class-fts-settings-page-options.php:4951
+msgid "Button"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2119
+#: admin/class-fts-settings-page-options.php:3492
+#: admin/class-fts-settings-page-options.php:4152
+#: admin/class-fts-settings-page-options.php:4955
+msgid "AutoScroll"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2142
+#: admin/class-fts-settings-page-options.php:3538
+#: admin/class-fts-settings-page-options.php:4198
+#: admin/class-fts-settings-page-options.php:5003
+msgid "Load more Button Width"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2142
+#: admin/class-fts-settings-page-options.php:3538
+#: admin/class-fts-settings-page-options.php:4198
+#: admin/class-fts-settings-page-options.php:5003
+msgid "Leave blank for auto width"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2170
+#: admin/class-fts-settings-page-options.php:3559
+#: admin/class-fts-settings-page-options.php:4220
+#: admin/class-fts-settings-page-options.php:5023
+msgid "Load more Button Margin"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2286
+msgid "Video Button Options"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2288
+msgid "Video Play Button"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2288
+msgid "Displays over Video Thumbnail"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2320
+msgid "Size of the Play Button"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2345
+msgid "Show Play Button in Front"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2345
+msgid "Displays before hovering over thumbnail"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2373
+msgid "Carousel/Slider"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2375
+msgid "Create a Carousel or Slideshow with these options."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2375
+msgid "View Demos"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2375
+msgid "and copy easy to use shortcode examples."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2377
+msgid "Carousel/Slideshow"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2383
+msgid "Off"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2387
+msgid "On"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2410
+msgid "Type"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2416
+msgid "Slideshow"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2420
+msgid "Carousel"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2441
+msgid "Carousel Slides Visible"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2441
+msgid "Not for Slideshow. Example: 1-500"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2445
+msgid "3 is the default number"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2467
+msgid "Spacing in between Slides"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2472
+msgid "2px"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2490
+msgid "Carousel/Slideshow Margin"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2490
+msgid "Center feed. Add space above/below."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2495
+msgid "-6px auto 1px auto"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2512
+msgid "Slider Speed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2512
+msgid "How fast the slider changes"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2517
+#: admin/class-fts-settings-page-options.php:2539
+msgid "0-10000"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2534
+msgid "Slider Timeout"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2534
+msgid "Amount of Time before the next slide."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2556
+msgid "Slider Controls"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2562
+msgid "Dots above Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2566
+msgid "Dots and Arrows above Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2570
+msgid "Dots and Numbers above Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2574
+msgid "Dots, Arrows and Numbers above Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2578
+msgid "Arrows and Numbers above feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2582
+msgid "Arrows above Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2586
+msgid "Numbers above Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2590
+msgid "Dots below Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2594
+msgid "Dots and Arrows below Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2598
+msgid "Dots and Numbers below Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2602
+msgid "Dots, Arrows and Numbers below Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2606
+msgid "Arrows below Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2610
+msgid "Numbers Below Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2628
+msgid "Slider Controls Text Color"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2651
+msgid "Slider Controls Bar Color"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2674
+msgid "Slider Controls Max Width"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2812
+msgid "Facebook Page Feed Shortcode"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2821
+msgid "Youtube Shortcode Generator"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2830
+msgid "See Example Demos"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2841
+msgid ""
+"<strong>STEP 1:</strong> Please add your API Token or Access Token to our <a "
+"href=\"admin.php?page=fts-youtube-feed-styles-submenu-page\">Youtube "
+"Options</a> page before getting started. "
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2875
+msgid "Single Video with title, date & description"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2889
+msgid "Youtube Username (required)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2890
+msgid ""
+"You must copy your YouTube <strong>Username</strong> url and paste it below. "
+"Your url should look similar to our Example url.<br/><strong>Example:</"
+"strong>"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2912
+#: admin/class-fts-settings-page-options.php:2936
+msgid "Youtube Playlist ID (required)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2913
+msgid ""
+"You must copy your YouTube <strong>Playlist</strong> and <strong>Channel</"
+"strong> url link and paste them below. Your urls should look similar to our "
+"Example urls below. <br/><br/><strong>Playlist ID:</strong>"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2913
+msgid "Channel ID:"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2937
+msgid ""
+"You must copy your YouTube <strong>Playlist</strong> and <strong>Username</"
+"strong> url and paste them below. Your urls should look similar to our "
+"Example urls below.<br/><br/><strong>Playlist ID:</strong>"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2937
+msgid "Username:"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2960
+msgid ""
+"Youtube Username<br/><small>Required if showing <a href=\"admin.php?page=fts-"
+"youtube-feed-styles-submenu-page\">Subscribe button</a></small>"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2981
+msgid "Youtube Channel ID (required)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:2982
+msgid ""
+"You must copy your YouTube <strong>Channel</strong> url and paste it below. "
+"Your url should look similar to our Example url.<br/><strong>Example:</"
+"strong>"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3004
+msgid ""
+"Youtube Channel ID<br/><small>Required if showing <a href=\"admin.php?"
+"page=fts-youtube-feed-styles-submenu-page\">Subscribe button</a></small>"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3025
+msgid "Single Youtube Video ID (required)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3026
+msgid ""
+"You must copy your <strong>YouTube Video</strong> url link and paste it "
+"below. Your url should look similar to our Example url below. <br/"
+"><strong>Video URL:</strong>"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3048
+#: includes/feed-them-functions.php:2646
+msgid "# of videos"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3052
+msgid "4 is the default value"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3069
+msgid "First Video Display"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3072
+#: includes/feed-them-functions.php:2648
+msgid "Display First video full size"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3096
+msgid "Show the Large Video Title"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3119
+msgid "Show the Large Video Description"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3140
+msgid "Video Thumbnails"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3143
+msgid "Click thumb to play Video"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3149
+msgid "Play on Page"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3153
+msgid "Open in YouTube"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3157
+msgid "Open in Popup (Premium Version Required)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3170
+#: includes/feed-them-functions.php:2647
+msgid "# of videos in each row"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3177
+#: admin/class-fts-settings-page-options.php:4781
+msgid "1"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3181
+#: admin/class-fts-settings-page-options.php:4785
+msgid "2"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3185
+#: admin/class-fts-settings-page-options.php:4789
+msgid "3"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3189
+#: admin/class-fts-settings-page-options.php:4793
+msgid "4"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3193
+#: admin/class-fts-settings-page-options.php:4797
+msgid "5"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3197
+#: admin/class-fts-settings-page-options.php:4801
+msgid "6"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3210
+msgid "Hide the first thumbnail"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3210
+msgid "Useful if playing videos on the page."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3234
+msgid "Space between video thumbnails"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3252
+msgid "Force thumbnails rows"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3252
+msgid ""
+"No, will allow the video images to be responsive for smaller devices. Yes, "
+"will force the selected rows."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3276
+msgid "High quality thumbnail images"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3300
+msgid "Container Background color "
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3319
+msgid "Align Thumbs"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3319
+msgid "Bottom (default), Right, or left of Videoo"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3325
+#: admin/class-fts-settings-page-options.php:3356
+msgid "Below Video"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3350
+msgid "Align Title, Description etc."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3350
+msgid "Bottom (default), Right, or left of Video"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3381
+msgid "Video/Thumbs width options"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3381
+#: admin/class-fts-settings-page-options.php:3416
+msgid "Sizes: 80/20, 60/40 or 50/50"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3387
+#: admin/class-fts-settings-page-options.php:3422
+msgid "None"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3391
+msgid "Option 1 (Video 80%, Thumbs Container 20%)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3395
+msgid "Option 1 (Video 60%, Thumbs Container 40%)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3399
+msgid "Option 1 (Video 50%, Thumbs Container 50%)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3416
+msgid "Video/Info width options"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3426
+msgid "Option 1 (Video 80%, Info Container 20%)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3430
+msgid "Option 1 (Video 60%, Info Container 40%)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3434
+msgid "Option 1 (Video 50%, Info Container 50%)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3513
+#: admin/class-fts-settings-page-options.php:4173
+#: admin/class-fts-settings-page-options.php:4976
+msgid "Load more Amount"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3513
+msgid "How many more videos will load at a time."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3517
+#: admin/class-fts-settings-page-options.php:4177
+#: admin/class-fts-settings-page-options.php:4980
+msgid "5 is the default number"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3579
+msgid "Comments"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3581
+msgid "# of Comments"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3581
+msgid "Maximum amount is 50"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3643
+msgid "YouTube Feed Shortcode"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3652
+msgid "Pinterest Shortcode Generator"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3672
+msgid ""
+"<strong>STEP 1:</strong> Please add a Pinterest API Token to our <a href="
+"\"admin.php?page=fts-pinterest-feed-styles-submenu-page\">Pinterest Options</"
+"a> page before getting started. "
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3682
+msgid "Board List"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3723
+msgid "Pinterest Board Name (required)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3728
+msgid "Pinterest and Board Name"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3728
+msgid "and paste them below."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3749
+msgid "Pinterest Username (required)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3769
+msgid "# of Boards"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3776
+#: admin/class-fts-settings-page-options.php:3800
+#: admin/class-fts-settings-page-options.php:3959
+#: admin/class-fts-settings-page-options.php:4562
+msgid "6 is the default value"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3793
+msgid "# of Pins"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3840
+msgid "Pinterest Feed Shortcode"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3849
+msgid "Twitter Shortcode Generator"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3860
+msgid ""
+"<strong>STEP 1:</strong> Please add Twitter API Tokens to our <a href="
+"\"admin.php?page=fts-twitter-feed-styles-submenu-page\">Twitter Options</a> "
+"page before getting started. "
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3902
+msgid ""
+"You can use #hashtag, @person, or single words. For example, weather or "
+"weather-channel.<br/><br/>If you want to filter a specific users hashtag "
+"copy this example into the first input below and replace the user_name and "
+"YourHashtag name. DO NOT remove the from: or %# characters. NOTE: Only "
+"displays last 7 days worth of Tweets. <strong style=\"color:#225DE2;\">from:"
+"user_name%#YourHashtag</strong>"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3933
+msgid "Twitter Name is only required if you want to show a"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3933
+msgid "Follow Button"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3952
+msgid "# of Tweets (optional)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3975
+msgid "Twitter Fixed Height"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:3992
+msgid "Show Cover Photo"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4014
+msgid "Stats Bar"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4036
+msgid "Show Retweets"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4058
+msgid "Show Replies"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4081
+#: admin/class-fts-settings-page-options.php:5045
+#: includes/feed-them-functions.php:2597
+msgid "Display Photos & Videos in Popup"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4173
+#: admin/class-fts-settings-page-options.php:4976
+msgid "How many more posts will load at a time."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4363
+msgid "Twitter Feed Shortcode"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4372
+msgid "Instagram Shortcode Generator"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4383
+msgid ""
+"<strong>STEP 1:</strong> Please get your Access Token on the <a href=\"admin."
+"php?page=fts-instagram-feed-styles-submenu-page\">Instagram Options</a> page "
+"before getting started. "
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4449
+msgid "Location ID (required)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4463
+msgid ""
+"<strong>NOTE:</strong> The post count may not count proper in some location "
+"instances because private instagram photos are in the mix. We cannot pull "
+"private accounts photos in any location feed. Add your Location ID below."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4493
+msgid ""
+"Add your hashtag below. <strong>DO NOT</strong> add the #, just the name. "
+"Only one hashtag allowed at this time. Hashtag media only stays on Instagram "
+"for 24 hours and the API does not give us a date/time. In order to use the "
+"Instagram hashtag feed you must have your Instagram account linked to a "
+"Facebook Business Page. <a target=\"_blank\" href=\"https://www.slickremix."
+"com/docs/link-instagram-account-to-facebook/\">Read Instructions.</a>"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4555
+msgid "# of Pics (optional)"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4589
+msgid "Gallery Width"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4611
+msgid "Gallery Fixed Height"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4611
+msgid "Use this option to create a scrolling feed."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4633
+msgid "Profile"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4635
+msgid "Show Profile Info"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4658
+msgid "Show Profile Photo"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4682
+msgid "Show Profile Stats"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4703
+msgid "Show Profile Name"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4724
+msgid "Show Profile Description"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4749
+msgid "Gallery Options"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4751
+msgid "Gallery Style"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4757
+msgid "Responsive Gallery"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4773
+msgid "Number of Columns"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4775
+msgid ""
+"Using the Columns option will make this gallery fully responsive and it will "
+"adapt in size to your containers width. Choose the Number of Columns and "
+"Space between each image below. Please add px after any number."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4775
+msgid "View demo"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4805
+msgid "7"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4809
+msgid "8"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4826
+msgid "Force Columns"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4826
+msgid ""
+"No, will allow the images to be responsive for smaller devices. Yes, will "
+"force columns."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4868
+msgid "Size of the Instagram Icon"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4869
+msgid "Visible when you hover over photo"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4886
+msgid "Date, Heart & Comment icon"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4886
+msgid "Heart and Comment counts only work when using Feed Type: Business Feed."
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4893
+msgid "Show"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4897
+msgid "Hide"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4914
+msgid "Load more posts"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:4944
+msgid "Load more style"
+msgstr ""
+
+#: admin/class-fts-settings-page-options.php:5106
+msgid "Instagram Feed Shortcode"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:44
+msgid ""
+"Warning: cURL is not installed on this server. It is required to use this "
+"plugin. Please contact your host provider to install this."
+msgstr ""
+
+#: admin/class-fts-settings-page.php:55 includes/feed-them-functions.php:2940
+msgid "Feed Them Social"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:65
+msgid "View Extensions & Demos"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:72
+msgid "Create Shortcode"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:76 includes/feed-them-functions.php:2989
+msgid "Global Options"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:82
+msgid "Create Shortcode for Social Network"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:83
+msgid ""
+"Please select what type of feed you would like using the select option "
+"below. After setting your options click the green Generate Shortcode button, "
+"then copy and paste the shortcode to a page, post or widget."
+msgstr ""
+
+#: admin/class-fts-settings-page.php:87
+msgid "Select a Social Network"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:88
+msgid "Facebook Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:89
+msgid "Combine Streams Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:90
+msgid "Twitter Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:91
+msgid "Instagram Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:92
+msgid "YouTube Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:93
+msgid "Pinterest Feed"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:99
+msgid ""
+"<br/><strong>STEP 2:</strong> Generate your custom shortcode using the "
+"options below, then click generate shortcode and paste that to a Page, Post "
+"or widget."
+msgstr ""
+
+#: admin/class-fts-settings-page.php:108 admin/class-fts-settings-page.php:135
+#, php-format
+msgid ""
+"%1$sSTEP 1:%2$s Please get your API Token on our %3$sFacebook Options%4$s "
+"page before getting started.%5$s"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:119
+#, php-format
+msgid ""
+"%1$sSTEP 1:%2$s Please add a Facebook Page Reviews API Token to our "
+"%3$sFacebook Options%4$s page before getting started.%5$s"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:187
+msgid "Clear All Cache Options"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:188
+msgid ""
+"Please Clear Cache if you have changed a Feed Them Social Shortcode. This "
+"will Allow you to see the changes right away."
+msgstr ""
+
+#: admin/class-fts-settings-page.php:199
+msgid "Clear All FTS Feeds Cache"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:205
+msgid "Cache Time"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:207
+msgid "Please choose an option"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:208
+msgid "1 Day ago (Suggested Default)"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:209 includes/feed-them-functions.php:3012
+msgid "2 Days"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:210 includes/feed-them-functions.php:3015
+msgid "3 Days"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:211 includes/feed-them-functions.php:3018
+msgid "1 Week"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:212 includes/feed-them-functions.php:3021
+msgid "2 Weeks"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:213
+msgid "(Developers Only) Clear cache on every page load"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:216
+msgid "Admin Bar"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:219
+msgid "Show Admin Bar Menu"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:222
+msgid "Hide Admin Bar Menu"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:240
+msgid "FaceBook & Twitter Date Format"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:281
+msgid "One Day Ago"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:284
+msgid "Use Custom Date and Time Option Below"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:309
+msgid "Translate words for 1 day ago option."
+msgstr ""
+
+#: admin/class-fts-settings-page.php:310 includes/feed-them-functions.php:3059
+msgid "second"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:313 includes/feed-them-functions.php:3063
+msgid "seconds"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:316 includes/feed-them-functions.php:3067
+msgid "minute"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:319 includes/feed-them-functions.php:3071
+msgid "minutes"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:322 includes/feed-them-functions.php:3075
+msgid "hour"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:325 includes/feed-them-functions.php:3079
+msgid "hours"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:328 includes/feed-them-functions.php:3083
+msgid "day"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:331 includes/feed-them-functions.php:3088
+msgid "days"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:334 includes/feed-them-functions.php:3092
+msgid "week"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:337 includes/feed-them-functions.php:3096
+msgid "weeks"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:340 includes/feed-them-functions.php:3100
+msgid "month"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:343 includes/feed-them-functions.php:3104
+msgid "months"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:346 includes/feed-them-functions.php:3108
+msgid "year"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:349 includes/feed-them-functions.php:3112
+msgid "years"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:352 includes/feed-them-functions.php:3116
+msgid "ago"
+msgstr ""
+
+#: admin/class-fts-settings-page.php:375
+msgid "Custom Date and Time"
+msgstr ""
+
+#: admin/class-fts-system-info-page.php:41
+msgid "Get Extensions Here!"
+msgstr ""
+
+#: admin/class-fts-system-info-page.php:44
+msgid "System Info"
+msgstr ""
+
+#: admin/class-fts-system-info-page.php:47
+msgid ""
+"Please click the box below and copy the report. You will need to paste this "
+"information along with your question when requesting"
+msgstr ""
+
+#: admin/class-fts-system-info-page.php:49 feed-them.php:353
+msgid "Support"
+msgstr ""
+
+#: admin/class-fts-system-info-page.php:51
+msgid ""
+"To copy the system info, click below then press Ctrl + C (PC) or Cmd + C "
+"(Mac)."
+msgstr ""
+
+#: admin/class-fts-system-info-page.php:54
+msgid ""
+"To copy the system info, click here then press Ctrl + C (PC) or Cmd + C "
+"(Mac)."
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:67
+msgid "Twitter Feed Options"
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:70
+msgid "Change the color of your twitter feed and more using the options below."
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:143
+msgid "Twitter API Token"
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:146
+msgid ""
+"This is required to make the feed work. Simply click the button below and it "
+"will connect to your Twitter account to get an access token and access token "
+"secret, and it will return it in the input below. Then just click the save "
+"button and you will now be able to generate your Twitter feed."
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:151
+#, php-format
+msgid "%1$sLogin and get my Access Tokens%2$s"
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:170
+msgid "Add your own tokens?"
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:178
+#, php-format
+msgid ""
+"Learn how to manually create the Consumer Key/Secret and the Access Token/"
+"Secret %1$shere%2$s."
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:186
+msgid "Consumer Key (API Key)"
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:193
+msgid "Consumer Secret (API Secret)"
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:213
+#: admin/class-fts-youtube-options-page.php:140
+#: admin/class-fts-youtube-options-page.php:223
+#: includes/feed-them-functions.php:3351
+msgid "Access Token"
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:221
+msgid "Access Token Secret"
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:233
+#, php-format
+msgid "%1$sOh No, something's wrong. "
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:238
+#, php-format
+msgid ""
+"%1$s%2$s%3$s You may have entered in the Access information incorrectly "
+"please re-enter and try again.%4$s"
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:247
+#, php-format
+msgid ""
+"%1$sYour access token is working! Generate your shortcode on the "
+"%2$sSettings Page%3$s.%4$s"
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:278
+msgid "Show Follow Count"
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:310
+msgid "Placement of Follow Button"
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:330
+msgid "Video Player Options"
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:334
+msgid "Show videos"
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:352
+#, php-format
+msgid ""
+"Convert shortlinks for video%1$sLike bitly etc. May slow load time slightly"
+"%2$s."
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:374
+msgid "Profile Photo Option"
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:378
+msgid "Hide Profile Photo"
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:396
+msgid "Style Options"
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:421
+msgid "Max-width for Feed Images"
+msgstr ""
+
+#: admin/class-fts-twitter-options-page.php:477
+#, php-format
+msgid "Feed Margin %1$sTo center feed type auto%2$s"
+msgstr ""
+
+#: admin/class-fts-youtube-options-page.php:46
+msgid "Feed Options"
+msgstr ""
+
+#: admin/class-fts-youtube-options-page.php:49
+msgid ""
+"Add a follow button and position it using the options below. This option "
+"will not work for combined feeds."
+msgstr ""
+
+#: admin/class-fts-youtube-options-page.php:81
+msgid "YouTube API Key"
+msgstr ""
+
+#: admin/class-fts-youtube-options-page.php:83
+msgid ""
+"This is required to make the feed work. Simply click the button below and it "
+"will connect to your YouTube account to get an access token and access token "
+"secret, and it will return it in the input below. Then just click the save "
+"button and you will now be able to generate your YouTube feed."
+msgstr ""
+
+#: admin/class-fts-youtube-options-page.php:88
+#, php-format
+msgid "%1$sLogin and get my Access Token (API key)%2$s"
+msgstr ""
+
+#: admin/class-fts-youtube-options-page.php:117
+msgid "Learn how to manually create your own YouTube API Key"
+msgstr ""
+
+#: admin/class-fts-youtube-options-page.php:118
+msgid "here"
+msgstr ""
+
+#: admin/class-fts-youtube-options-page.php:122
+msgid "API Key Required"
+msgstr ""
+
+#: admin/class-fts-youtube-options-page.php:133
+msgid "Refresh Token"
+msgstr ""
+
+#: admin/class-fts-youtube-options-page.php:155
+msgid "Expiration Time for Access Token"
+msgstr ""
+
+#: admin/class-fts-youtube-options-page.php:221
+#: includes/feed-them-functions.php:3349
+msgid "API key"
+msgstr ""
+
+#: admin/class-fts-youtube-options-page.php:229
+#, php-format
+msgid ""
+"%1$s Your %2$s is working! Generate your shortcode on the %3$s settings page."
+"%4$s %5$s"
+msgstr ""
+
+#: admin/class-fts-youtube-options-page.php:238
+#, php-format
+msgid ""
+"%1$s This %2$s does not appear to be valid. YouTube responded with: %3$s "
+"%4$s "
+msgstr ""
+
+#: admin/class-fts-youtube-options-page.php:247
+#, php-format
+msgid ""
+"%1$s You must click the button above or register for an API token to use the "
+"YouTube feed.%2$s"
+msgstr ""
+
+#: feed-them.php:172
+msgid ""
+"Thanks for updating Feed Them Social. We have deleted the cache in our "
+"plugin so you can view any changes we have made."
+msgstr ""
+
+#: feed-them.php:188
+#, php-format
+msgid ""
+"Thanks for installing Feed Them Social. To get started please view our "
+"%1$sSettings%2$s page."
+msgstr ""
+
+#: feed-them.php:327
+#, php-format
+msgid ""
+"%1$s Feed Them Social Warning:%2$s Your php version is %1$s%3$s%2$s. You "
+"need to be running at least %1$s5.3%2$s or greater to use this plugin. "
+"Please upgrade the php by contacting your host provider. Some host providers "
+"will allow you to change this yourself in the hosting control panel too. "
+"%4$s If you are hosting with BlueHost or Godaddy and the php version above "
+"is saying you are running %1$s5.2.17%2$s but you are really running "
+"something higher please %5$sclick here for the fix%6$s. If you cannot get it "
+"to work using the method described in the link please contact your host "
+"provider and explain the problem so they can fix it."
+msgstr ""
+
+#: feed-them.php:353 includes/feed-them-functions.php:2981
+msgid "Settings"
+msgstr ""
+
+#: feed-them.php:370
+msgid "Rate Plugin"
+msgstr ""
+
+#: feed-them.php:500
+msgid ""
+"It's great to see that you've been using our Feed Them Social plugin for a "
+"while now. Hopefully you're happy with it!  If so, would you consider "
+"leaving a positive review? It really helps support the plugin and helps "
+"others discover it too!"
+msgstr ""
+
+#: feed-them.php:502
+msgid "Sure, I'd love to"
+msgstr ""
+
+#: feed-them.php:503
+msgid "I've already given a review"
+msgstr ""
+
+#: feed-them.php:504
+msgid "Ask me later"
+msgstr ""
+
+#: feed-them.php:505
+msgid "Not working, I need support"
+msgstr ""
+
+#: feed-them.php:506
+msgid "No thanks"
+msgstr ""
+
+#: feeds/facebook/class-fts-facebook-feed-post-types.php:218
+msgid "Picture from Facebook"
+msgstr ""
+
+#: feeds/facebook/class-fts-facebook-feed-post-types.php:444
+msgid "View Album"
+msgstr ""
+
+#: feeds/facebook/class-fts-facebook-feed-post-types.php:469
+msgid "View more for this Album"
+msgstr ""
+
+#: feeds/facebook/class-fts-facebook-feed-post-types.php:470
+msgid "of"
+msgstr ""
+
+#: feeds/facebook/class-fts-facebook-feed-post-types.php:470
+msgid "Photos"
+msgstr ""
+
+#: feeds/facebook/class-fts-facebook-feed-post-types.php:487
+#: feeds/facebook/class-fts-facebook-feed-post-types.php:505
+msgid "View Photo"
+msgstr ""
+
+#: feeds/facebook/class-fts-facebook-feed-post-types.php:494
+msgid "View Video"
+msgstr ""
+
+#: feeds/facebook/class-fts-facebook-feed.php:2010
+msgid "..."
+msgstr ""
+
+#: feeds/instagram/class-fts-instagram-feed.php:266
+msgid "View on Instagram"
+msgstr ""
+
+#: feeds/instagram/class-fts-instagram-feed.php:372
+msgid "No More Photos"
+msgstr ""
+
+#: feeds/instagram/class-fts-instagram-feed.php:433
+#: feeds/instagram/class-fts-instagram-feed.php:503
+#: feeds/instagram/class-fts-instagram-feed.php:561
+msgid "Array Check Cached"
+msgstr ""
+
+#: feeds/instagram/class-fts-instagram-feed.php:586
+msgid "Array Check"
+msgstr ""
+
+#: feeds/instagram/class-fts-instagram-feed.php:601
+msgid "Cached"
+msgstr ""
+
+#: feeds/instagram/class-fts-instagram-feed.php:608
+msgid ""
+"The Legacy API is depreciated as of March 31st, 2020 in favor of the new "
+"Instagram Graph API and the Instagram Basic Display API. Please go to the "
+"instagram Options page of our plugin and reconnect your account and generate "
+"a new shortcode and replace your existing one."
+msgstr ""
+
+#: feeds/instagram/class-fts-instagram-feed.php:614
+msgid ""
+"Please go to the Feed Them > Instagram Options page of our Feed Them Social "
+"plugin a double check your Instagram ID matches the one used in your "
+"shortcode on this page."
+msgstr ""
+
+#: feeds/instagram/class-fts-instagram-feed.php:617
+msgid "Feed Them Social (Notice visible to Admin only). Instagram returned:"
+msgstr ""
+
+#: feeds/instagram/class-fts-instagram-feed.php:626
+msgid "Not Cached"
+msgstr ""
+
+#: feeds/pinterest/class-fts-pinterest-feed.php:117
+msgid "View on Pinterest"
+msgstr ""
+
+#: feeds/pinterest/class-fts-pinterest-feed.php:364
+msgid "Pinterest Photo"
+msgstr ""
+
+#: feeds/pinterest/class-fts-pinterest-feed.php:375
+msgid "Pinterest Attribution Icon"
+msgstr ""
+
+#: feeds/twitter/class-fts-twitter-feed.php:330
+msgid "No More Tweets"
+msgstr ""
+
+#: feeds/twitter/class-fts-twitter-feed.php:529
+msgid "Oops, Somethings wrong. "
+msgstr ""
+
+#: feeds/twitter/class-fts-twitter-feed.php:531
+msgid ""
+" Please check that you have entered your Twitter API token information "
+"correctly on the Twitter Options page of Feed Them Social."
+msgstr ""
+
+#: feeds/twitter/class-fts-twitter-feed.php:534
+msgid ""
+" Please check the Twitter Username you have entered is correct in your "
+"shortcode for Feed Them Social."
+msgstr ""
+
+#: feeds/twitter/class-fts-twitter-feed.php:538
+msgid ""
+"No Access Tokens have been set. Please retrieve Twitter API tokens on the "
+"Twitter Options page of Feed Them Social."
+msgstr ""
+
+#: feeds/twitter/class-fts-twitter-feed.php:541
+msgid ""
+" This account has no tweets. Please Tweet to see this feed. Feed Them Social."
+msgstr ""
+
+#: feeds/twitter/class-fts-twitter-feed.php:547
+msgid ""
+"Rate Limited Exceeded. Please go to the Feed Them Social Plugin then the "
+"Twitter Options page for Feed Them Social and follow the instructions under "
+"the header Twitter API Token."
+msgstr ""
+
+#: feeds/twitter/class-fts-twitter-feed.php:555
+msgid "No Tweets available. Login as Admin to see more details."
+msgstr ""
+
+#: feeds/twitter/class-fts-twitter-feed.php:638
+msgid "Followers:"
+msgstr ""
+
+#: feeds/twitter/class-fts-twitter-feed.php:644
+msgid "Tweets"
+msgstr ""
+
+#: feeds/twitter/class-fts-twitter-feed.php:645
+msgid "Following"
+msgstr ""
+
+#: feeds/twitter/class-fts-twitter-feed.php:646
+msgid "Followers"
+msgstr ""
+
+#: feeds/twitter/class-fts-twitter-feed.php:647
+msgid "Likes"
+msgstr ""
+
+#: feeds/youtube/class-youtube-feed-free.php:422
+#: feeds/youtube/class-youtube-feed-free.php:511
+#: feeds/youtube/class-youtube-feed-free.php:547
+msgid "View on YouTube"
+msgstr ""
+
+#: feeds/youtube/class-youtube-feed-free.php:567
+msgid "No More Videos"
+msgstr ""
+
+#: includes/error-handler.php:51
+msgid "Feed Them Premium"
+msgstr ""
+
+#: includes/error-handler.php:55
+msgid "FTS Bar"
+msgstr ""
+
+#: includes/error-handler.php:59
+msgid "Feed Them Social Facebook Reviews"
+msgstr ""
+
+#: includes/error-handler.php:63
+msgid "Feed Them Carousel Premium"
+msgstr ""
+
+#: includes/error-handler.php:67
+msgid "Feed Them Social Combined Streams"
+msgstr ""
+
+#: includes/error-handler.php:85
+msgid ""
+"Please update ALL Premium Extensions for Feed Them Social because they will "
+"no longer work with this version of Feed Them Social. We have made some "
+"Major Changes to the Core of the plugin to help with plugin conflicts. "
+"Please update your extensions from your <a href=\"https://www.slickremix.com/"
+"my-account\" target=\"_blank\">My Account</a> page on our website if you are "
+"not receiving notifications for updates on the premium extensions. Thanks "
+"again for using our plugin!"
+msgstr ""
+
+#: includes/feed-them-functions.php:198
+#, php-format
+msgid ""
+"%1$sOh No something's wrong. %2$s. Please try clicking the button again to "
+"get a new access token. If you need additional assistance please email us at "
+"support@slickremix.com %3$s."
+msgstr ""
+
+#: includes/feed-them-functions.php:263
+msgid "Social Share Options"
+msgstr ""
+
+#: includes/feed-them-functions.php:327
+msgid ""
+"Click on a page in the list below and it will add the Page ID and Access "
+"Token above, then click save."
+msgstr ""
+
+#: includes/feed-them-functions.php:355 includes/feed-them-functions.php:415
+msgid "ID: "
+msgstr ""
+
+#: includes/feed-them-functions.php:380
+msgid "Location for"
+msgstr ""
+
+#: includes/feed-them-functions.php:380
+msgid "Locations for"
+msgstr ""
+
+#: includes/feed-them-functions.php:420
+msgid "Location:"
+msgstr ""
+
+#: includes/feed-them-functions.php:454
+msgid "Scroll to view more Locations"
+msgstr ""
+
+#: includes/feed-them-functions.php:2598
+msgid "Load More Posts"
+msgstr ""
+
+#: includes/feed-them-functions.php:2645
+msgid "YouTube Name"
+msgstr ""
+
+#: includes/feed-them-functions.php:2949
+msgid "Cache clears on page refresh now"
+msgstr ""
+
+#: includes/feed-them-functions.php:2958
+msgid "Clear Cache"
+msgstr ""
+
+#: includes/feed-them-functions.php:2968
+#, php-format
+msgid "Set Cache Time %1$s%2$s%3$s"
+msgstr ""
+
+#: includes/feed-them-functions.php:3005
+msgid "Clear cache on every page load"
+msgstr ""
+
+#: includes/feed-them-functions.php:3009
+msgid "1 Day (Default)"
+msgstr ""
+
+#: updater/updater-check-class.php:84
+#, php-format
+msgid ""
+"%1$s needs a valid License Key! %2$sClick here to add one%4$s or you will "
+"not receive update notices in WordPress. - %3$sGet your License Key Here%4$s."
+msgstr ""
+
+#: updater/updater-check-class.php:109
+#, php-format
+msgid ""
+"%1$s - Your License Key is not active, expired, or is invalid. %2$sClick "
+"here to add one%4$s or you will not receive update notices in WordPress. - "
+"%3$sGet your License Key Here%4$s."
+msgstr ""
+
+#: updater/updater-check-class.php:281
+#, php-format
+msgid ""
+"There is a new version of %1$s available. %2$sView version %3$s details%4$s."
+msgstr ""
+
+#: updater/updater-check-class.php:289
+#, php-format
+msgid ""
+"There is a new version of %1$s available. %2$sView version %3$s details%4$s "
+"or %5$supdate now%6$s."
+msgstr ""
+
+#: updater/updater-check-class.php:453
+msgid "You do not have permission to install plugin updates"
+msgstr ""
+
+#: updater/updater-check-class.php:453
+msgid "Error"
+msgstr ""
+
+#: updater/updater-license-page.php:139
+msgid "License Key Active."
+msgstr ""
+
+#: updater/updater-license-page.php:149
+msgid "To receive updates notifications, please enter your valid license key."
+msgstr ""
+
+#: updater/updater-license-page.php:174
+msgid "Plugin License"
+msgstr ""
+
+#: updater/updater-license-page.php:186
+msgid "Plugin License Options"
+msgstr ""
+
+#: updater/updater-license-page.php:190
+#, php-format
+msgid ""
+"If you need more licenses or your key has expired, please go to the %1$sMY "
+"ACCOUNT%2$s page on our website to upgrade or renew your license.%3$sTo get "
+"started follow the instructions below."
+msgstr ""
+
+#: updater/updater-license-page.php:203
+#, php-format
+msgid ""
+"Install the zip file of the plugin you should have received after purchase "
+"on the %1$splugins page%2$s and leave the free version active too."
+msgstr ""
+
+#: updater/updater-license-page.php:212
+#, php-format
+msgid "Now Enter your License Key and Click the %1$sSave Changes button%2$s."
+msgstr ""
+
+#: updater/updater-license-page.php:403 updater/updater-license-page.php:441
+#: updater/updater-license-page.php:494
+msgid "An error occurred, please try again."
+msgstr ""
+
+#: updater/updater-license-page.php:414
+#, php-format
+msgid "Your license key expired on %s."
+msgstr ""
+
+#: updater/updater-license-page.php:420
+msgid "Your license key has been disabled."
+msgstr ""
+
+#: updater/updater-license-page.php:424
+msgid "Invalid license."
+msgstr ""
+
+#: updater/updater-license-page.php:429
+msgid "Your license is not active for this URL."
+msgstr ""
+
+#: updater/updater-license-page.php:433
+#, php-format
+msgid "This appears to be an invalid license key for %s."
+msgstr ""
+
+#: updater/updater-license-page.php:437
+msgid "Your license key has reached its activation limit."
+msgstr ""
+
+#. Plugin Name of the plugin/theme
+msgid "Feed Them Social - for Twitter feed, Youtube, and more"
+msgstr ""
+
+#. Plugin URI of the plugin/theme
+msgid "https://feedthemsocial.com/"
+msgstr ""
+
+#. Description of the plugin/theme
+msgid ""
+"Display a Custom Facebook feed, Instagram feed, Twitter feed and YouTube "
+"feed on pages, posts or widgets."
+msgstr ""
+
+#. Author of the plugin/theme
+msgid "SlickRemix"
+msgstr ""
+
+#. Author URI of the plugin/theme
+msgid "https://www.slickremix.com/"
+msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -77,7 +77,8 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
 == Changelog ==
 = Version 2.9.2 Wednesday, January 6th, 2020 =
   * NOTE: Pinterest Feed: Removed options until Pinterest starts approving apps for the new API.
-  * FIX: FACEBOOK, INSTAGRAM & YOUTUBE OPTIONS PAGE: access_token in the url was causing some sites pages to return a "The link you followed has expired" making it impossible to get an access token.
+  * NEW: A feed-them-social.pot file is in the languages folder of our plugin.
+  * FIX: FACEBOOK, INSTAGRAM & YOUTUBE OPTIONS PAGE: access_token in the url was causing some websites to return a "The link you followed has expired" message making it impossible to get an access token.
 
 = Version 2.9.1 Wednesday, December 9th, 2020 =
   * NOTE: Pinterest Feed: We will be removing this feed and options page on our next update temporarily until they get the API complete.

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
-=== Feed Them Social - for Twitter feed, Youtube, Pinterest and more ===
+=== Feed Them Social - for Twitter feed, Youtube and more ===
 Contributors: slickremix, slickchris
 Tags: Facebook, Instagram, Twitter, YouTube, Feed
 Requires at least: 3.6.0
 Tested up to: 5.6.0
-Stable tag: 2.9.1
+Stable tag: 2.9.2
 License: GPLv2 or later
 
 Display a Custom Facebook feed, Instagram feed, Twitter feed, Pinterest feed & YouTube feed on pages, posts or widgets.
@@ -75,16 +75,20 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
   * Log into WordPress dashboard then click **Plugins** > **Add new** > Then under the title "Install Plugins" click **Upload** > **choose the zip** > **Activate the plugin!**
 
 == Changelog ==
-Version 2.9.1 Wednesday, December 9th, 2020 =
+= Version 2.9.2 Wednesday, January 6th, 2020 =
+  * NOTE: Pinterest Feed: Removed options until Pinterest starts approving apps for the new API.
+  * FIX: FACEBOOK, INSTAGRAM & YOUTUBE OPTIONS PAGE: access_token in the url was causing some sites pages to return a "The link you followed has expired" making it impossible to get an access token.
+
+= Version 2.9.1 Wednesday, December 9th, 2020 =
   * NOTE: Pinterest Feed: We will be removing this feed and options page on our next update temporarily until they get the API complete.
   * TESTED: Tested plugin with WordPress version 5.6.0.
 
-Version 2.9.0 Thursday, October 29th, 2020 =
+= Version 2.9.0 Thursday, October 29th, 2020 =
   * FIX: INSTAGRAM FEED: Missing images for videos.
   * PREMIUM FIX: INSTAGRAM FEED: Pop for images.
   * PREMIUM FIX COMING: INSTAGRAM HASHTAG FEED: Images for Videos are missing.
 
-Version 2.8.9 Friday, September 18th, 2020 =
+= Version 2.8.9 Friday, September 18th, 2020 =
   * FIX: FACEBOOK & INSTAGRAM OPTIONS PAGE: missing pages_read_engagement scope so non admins of our APP can gain access to pages they manage.
 
 = Version 2.8.8 Thursday, September 17th, 2020 =

--- a/readme.txt
+++ b/readme.txt
@@ -77,7 +77,7 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
 == Changelog ==
 = Version 2.9.2 Wednesday, January 6th, 2020 =
   * NOTE: Pinterest Feed: Removed options until Pinterest starts approving apps for the new API.
-  * NEW: A feed-them-social.pot file is in the languages folder of our plugin.
+  * NEW: A feed-them-social.pot file is in the languages folder of our plugin along with our latest translatable strings.
   * FIX: FACEBOOK, INSTAGRAM & YOUTUBE OPTIONS PAGE: access_token in the url was causing some websites to return a "The link you followed has expired" message making it impossible to get an access token.
 
 = Version 2.9.1 Wednesday, December 9th, 2020 =

--- a/updater/updater-check-class.php
+++ b/updater/updater-check-class.php
@@ -81,7 +81,7 @@ class updater_check_class {
 			<p>
 			<?php
 				echo sprintf(
-					esc_html( '%1$s needs a valid License Key! %2$sClick here to add one%4$s or you will not receive update notices in WordPress. - %3$sGet your License Key Here%4$s.', 'feed-them-social' ),
+					esc_html__( '%1$s needs a valid License Key! %2$sClick here to add one%4$s or you will not receive update notices in WordPress. - %3$sGet your License Key Here%4$s.', 'feed-them-social' ),
 					esc_html( $this->plugin_name ),
 					'<a href="' . esc_url( 'admin.php?page=fts-license-page' ) . '">',
 					'<a href="' . esc_url( 'https://www.slickremix.com/my-account/' ) . '" target="_blank">',
@@ -106,7 +106,7 @@ class updater_check_class {
 			<p>
 				<?php
 				echo sprintf(
-					esc_html( '%1$s - Your License Key is not active, expired, or is invalid. %2$sClick here to add one%4$s or you will not receive update notices in WordPress. - %3$sGet your License Key Here%4$s.', 'feed-them-social' ),
+					esc_html__( '%1$s - Your License Key is not active, expired, or is invalid. %2$sClick here to add one%4$s or you will not receive update notices in WordPress. - %3$sGet your License Key Here%4$s.', 'feed-them-social' ),
 					esc_html( $this->plugin_name ),
 					'<a href="' . esc_url( 'admin.php?page=fts-license-page' ) . '">',
 					'<a href="' . esc_url( 'https://www.slickremix.com/my-account/' ) . '" target="_blank">',
@@ -278,7 +278,7 @@ class updater_check_class {
 
 			if ( empty( $version_info->download_link ) ) {
 				printf(
-					esc_html( 'There is a new version of %1$s available. %2$sView version %3$s details%4$s.', 'feed-them-social' ),
+					esc_html__( 'There is a new version of %1$s available. %2$sView version %3$s details%4$s.', 'feed-them-social' ),
 					esc_html( $version_info->name ),
 					'<a target="_blank" class="thickbox" href="' . esc_url( $changelog_link ) . '">',
 					esc_html( $version_info->new_version ),
@@ -286,7 +286,7 @@ class updater_check_class {
 				);
 			} else {
 				printf(
-					esc_html( 'There is a new version of %1$s available. %2$sView version %3$s details%4$s or %5$supdate now%6$s.', 'feed-them-social' ),
+					esc_html__( 'There is a new version of %1$s available. %2$sView version %3$s details%4$s or %5$supdate now%6$s.', 'feed-them-social' ),
 					esc_html( $version_info->name ),
 					'<a target="_blank" class="thickbox" href="' . esc_url( $changelog_link ) . '">',
 					esc_html( $version_info->new_version ),
@@ -450,7 +450,7 @@ class updater_check_class {
 		}
 
 		if ( ! current_user_can( 'update_plugins' ) ) {
-			wp_die( esc_html( 'You do not have permission to install plugin updates', 'feed-them-social' ), esc_html( 'Error', 'feed-them-social' ), array( 'response' => 403 ) );
+			wp_die( esc_html__( 'You do not have permission to install plugin updates', 'feed-them-social' ), esc_html__( 'Error', 'feed-them-social' ), array( 'response' => 403 ) );
 		}
 
 		$data         = $edd_plugin_data[ $_REQUEST['slug'] ];

--- a/updater/updater-license-page.php
+++ b/updater/updater-license-page.php
@@ -136,7 +136,7 @@ class updater_license_page {
 						<?php wp_nonce_field( 'license_page_nonce', 'license_page_nonce' ); ?>
 						<input type="submit" class="button-secondary" name="<?php echo esc_html( $key ); ?>_license_deactivate" value="<?php echo esc_html( ( 'Deactivate License' ) ); ?>"/>
 
-						<div class="edd-license-data"><p><?php echo esc_html( 'License Key Active.' ); ?></p></div>
+						<div class="edd-license-data"><p><?php echo esc_html__( 'License Key Active.', 'feed-them-social' ); ?></p></div>
 
 						<?php
 } else {
@@ -146,7 +146,7 @@ class updater_license_page {
 							<p><?php echo esc_html( $license_error ); ?>
 								<?php
 								$this->update_admin_notices();
-								echo esc_html( 'To receive updates notifications, please enter your valid license key.' );
+								echo esc_html__( 'To receive updates notifications, please enter your valid license key.', 'feed-them-social' );
 								?>
 								</p>
 						</div>
@@ -183,11 +183,11 @@ class updater_license_page {
 
 		?>
 		<div class="wrap">
-			<h2><?php echo esc_html( 'Plugin License Options' ); ?></h2>
+			<h2><?php echo esc_html__( 'Plugin License Options', 'feed-them-social' ); ?></h2>
 			<div class="license-note">
 				<?php
 				echo sprintf(
-					esc_html( 'If you need more licenses or your key has expired, please go to the %1$sMY ACCOUNT%2$s page on our website to upgrade or renew your license.%3$sTo get started follow the instructions below.', 'feed-them-social' ),
+					esc_html__( 'If you need more licenses or your key has expired, please go to the %1$sMY ACCOUNT%2$s page on our website to upgrade or renew your license.%3$sTo get started follow the instructions below.', 'feed-them-social' ),
 					'<a href="' . esc_url( 'https://www.slickremix.com/my-account/' ) . '" target="_blank">',
 					'</a>',
 					'<br/>'
@@ -200,7 +200,7 @@ class updater_license_page {
 					<li>
 					<?php
 					echo sprintf(
-						esc_html( 'Install the zip file of the plugin you should have received after purchase on the %1$splugins page%2$s and leave the free version active too.', 'feed-them-social' ),
+						esc_html__( 'Install the zip file of the plugin you should have received after purchase on the %1$splugins page%2$s and leave the free version active too.', 'feed-them-social' ),
 						'<a href="' . esc_url( 'plugin-install.php' ) . '" target="_blank">',
 						'</a>'
 					);
@@ -209,7 +209,7 @@ class updater_license_page {
 					<li>
 					<?php
 					echo sprintf(
-						esc_html( 'Now Enter your License Key and Click the %1$sSave Changes button%2$s.', 'feed-them-social' ),
+						esc_html__( 'Now Enter your License Key and Click the %1$sSave Changes button%2$s.', 'feed-them-social' ),
 						'<strong>',
 						'</strong>'
 					);
@@ -411,7 +411,7 @@ class updater_license_page {
 
 					case 'expired':
 						$message = sprintf(
-							esc_html( 'Your license key expired on %s.' ),
+							esc_html__( 'Your license key expired on %s.', 'feed-them-social' ),
 							date_i18n( get_option( 'date_format' ), strtotime( $license_data->expires, time() ) )
 						);
 						break;
@@ -430,7 +430,7 @@ class updater_license_page {
 						break;
 
 					case 'item_name_mismatch':
-						$message = sprintf( esc_html( 'This appears to be an invalid license key for %s.' ), $this->prem_plugins[ $key ]['title'] );
+						$message = sprintf( esc_html__( 'This appears to be an invalid license key for %s.', 'feed-them-social' ), $this->prem_plugins[ $key ]['title'] );
 						break;
 
 					case 'no_activations_left':


### PR DESCRIPTION
= Version 2.9.2 Wednesday, January 6th, 2020 =
  * NOTE: Pinterest Feed: Removed options until Pinterest starts approving apps for the new API.
  * NEW: A feed-them-social.pot file is in the languages folder of our plugin along with our latest translatable strings.
  * FIX: FACEBOOK, INSTAGRAM & YOUTUBE OPTIONS PAGE: access_token in the url was causing some websites to return a "The link you followed has expired" message making it impossible to get an access token.