### PR TITLE
2.9.2.0

### DIFF
--- a/includes/feed-them-functions.php
+++ b/includes/feed-them-functions.php
@@ -3304,10 +3304,10 @@ if ( ! empty( $youtube_loadmore_text_color ) ) {
 
 			// Used some methods from this link http://ieg.wnet.org/2015/09/using-oauth-in-wordpress-plugins-part-2-persistence/
 			// save all 3 get options: happens when clicking the get access token button on the youtube options page!
-			if ( isset( $_GET['refresh_token'], $_GET['access_token'] ) && isset( $_GET['expires_in'] ) ) {
+			if ( isset( $_GET['refresh_token'], $_GET['code'] ) && isset( $_GET['expires_in'] ) ) {
 				$button_pushed                     = 'yes';
 				$clienttoken_post['refresh_token'] = sanitize_text_field( wp_unslash( $_GET['refresh_token'] ) );
-				$auth_obj['access_token']          = sanitize_text_field( wp_unslash( $_GET['access_token'] ) );
+				$auth_obj['access_token']          = sanitize_text_field( wp_unslash( $_GET['code'] ) );
 				$auth_obj['expires_in']            = sanitize_key( wp_unslash( $_GET['expires_in'] ) );
 			} else {
 				// refresh token!
@@ -3377,7 +3377,7 @@ if ( ! empty( $youtube_loadmore_text_color ) ) {
 								?>
 							jQuery('#youtube_custom_access_token, #youtube_custom_token_exp_time').val('');
 
-								<?php if ( isset( $_GET['refresh_token'], $_GET['access_token'] ) && isset( $_GET['expires_in'] ) ) { ?>
+								<?php if ( isset( $_GET['refresh_token'], $_GET['code'] ) && isset( $_GET['expires_in'] ) ) { ?>
 							jQuery('#youtube_custom_refresh_token').val(jQuery('#youtube_custom_refresh_token').val() + '<?php echo esc_js( $clienttoken_post['refresh_token'] ); ?>');
 							jQuery('.fts-failed-api-token').hide();
 

--- a/readme.txt
+++ b/readme.txt
@@ -75,7 +75,7 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
   * Log into WordPress dashboard then click **Plugins** > **Add new** > Then under the title "Install Plugins" click **Upload** > **choose the zip** > **Activate the plugin!**
 
 == Changelog ==
-= Version 2.9.2 Wednesday, January 6th, 2020 =
+= Version 2.9.2 Wednesday, January 6th, 2021 =
   * NOTE: Pinterest Feed: Removed options until Pinterest starts approving apps for the new API.
   * NEW: A feed-them-social.pot file is in the languages folder of our plugin along with our latest translatable strings.
   * FIX: FACEBOOK, INSTAGRAM & YOUTUBE OPTIONS PAGE: access_token in the url was causing some websites to return a "The link you followed has expired" message making it impossible to get an access token.


### PR DESCRIPTION
= Version 2.9.2 Wednesday, January 6th, 2021 =
  * NOTE: Pinterest Feed: Removed options until Pinterest starts approving apps for the new API.
  * NEW: A feed-them-social.pot file is in the languages folder of our plugin along with our latest translatable strings.
  * FIX: FACEBOOK, INSTAGRAM & YOUTUBE OPTIONS PAGE: access_token in the url was causing some websites to return a "The link you followed has expired" message making it impossible to get an access token.