### PR TITLE
2.9.2.0

### DIFF
--- a/admin/class-fts-settings-page-options.php
+++ b/admin/class-fts-settings-page-options.php
@@ -688,7 +688,7 @@ class FTS_Settings_Page_Options {
                     ),
 
 					// Combine Pinterest
-					array(
+					/* array(
 						'grouped_options_title' => __( 'Pinterest', 'feed-them-social' ),
 						'option_type' => 'select',
 						'label'       => __( 'Combine Pinterest', 'feed-them-social' ),
@@ -714,7 +714,7 @@ class FTS_Settings_Page_Options {
 						'sub_options' => array(
 							'sub_options_wrap_class' => 'main-combine-pinterest-wrap',
 						),
-					),
+					), */
 
 					// Pinterest Type
 					array(


### PR DESCRIPTION
= Version 2.9.2 Wednesday, January 6th, 2021 =
  * NOTE: Pinterest Feed: Removed options until Pinterest starts approving apps for the new API.
  * NEW: A feed-them-social.pot file is in the languages folder of our plugin along with our latest translatable strings.
  * FIX: FACEBOOK, INSTAGRAM & YOUTUBE OPTIONS PAGE: access_token in the url was causing some websites to return a "The link you followed has expired" message making it impossible to get an access token.