### PR TITLE
2.9.3

### DIFF
--- a/feed-them.php
+++ b/feed-them.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social - for Twitter feed, Youtube, and more
  * Plugin URI: https://feedthemsocial.com/
  * Description: Display a Custom Facebook feed, Instagram feed, Twitter feed and YouTube feed on pages, posts or widgets.
- * Version: 2.9.2
+ * Version: 2.9.3
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 4.0.0
  * Tested up to: WordPress 5.6.0
- * Stable tag: 2.9.2
+ * Stable tag: 2.9.3
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    2.9.2
+ * @version    2.9.3
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2021 SlickRemix
  *
@@ -31,7 +31,7 @@
  *
  * Makes sure any js or css changes are reloaded properly. Added to enqued css and js files throughout!
  */
-define( 'FTS_CURRENT_VERSION', '2.9.2' );
+define( 'FTS_CURRENT_VERSION', '2.9.3' );
 
 define( 'FEED_THEM_SOCIAL_NOTICE_STATUS', get_option( 'rating_fts_slick_notice', false ) );
 


### PR DESCRIPTION
= Version 2.9.3 Wednesday, January 27th, 2021 =
  * FIX: INSTAGRAM & FACEBOOK OPTIONS PAGE: #100 error was returning on tokens even though they were valid. FB changed the error text which resulted in the error message showing up instead of the success message.
  * FIX: GLOBAL OPTIONS: Date Time was not working proper for Instagram if you chose something other than the 'One Day Ago' option. The text Minute or Minutes was not returning either for the 'One Day Ago' option.
  * PREMIUM NEW: INSTAGRAM HASHTAG FEED: Timestamp is now added to media.
  * PREMIUM FIX: INSTAGRAM HASHTAG FEED: Better caching.
  * PREMIUM FIX: INSTAGRAM HASHTAG FEED: Video image was not displaying correctly.