### PR TITLE
2.9.4

### DIFF
--- a/feed-them.php
+++ b/feed-them.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social - for Twitter feed, Youtube, and more
  * Plugin URI: https://feedthemsocial.com/
  * Description: Display a Custom Facebook feed, Instagram feed, Twitter feed and YouTube feed on pages, posts or widgets.
- * Version: 2.9.3
+ * Version: 2.9.4
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 4.0.0
- * Tested up to: WordPress 5.6.0
- * Stable tag: 2.9.3
+ * Tested up to: WordPress 5.6.2
+ * Stable tag: 2.9.4
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    2.9.3
+ * @version    2.9.4
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2021 SlickRemix
  *
@@ -31,7 +31,7 @@
  *
  * Makes sure any js or css changes are reloaded properly. Added to enqued css and js files throughout!
  */
-define( 'FTS_CURRENT_VERSION', '2.9.3' );
+define( 'FTS_CURRENT_VERSION', '2.9.4' );
 
 define( 'FEED_THEM_SOCIAL_NOTICE_STATUS', get_option( 'rating_fts_slick_notice', false ) );
 

--- a/feeds/facebook/class-fts-facebook-feed-post-types.php
+++ b/feeds/facebook/class-fts-facebook-feed-post-types.php
@@ -190,8 +190,9 @@ class FTS_Facebook_Feed_Post_Types extends FTS_Facebook_Feed {
 		$lcs_array = $this->get_likes_shares_comments( $response_post_array, $post_data_key, $fb_post_share_count );
 
 		// echo '<pre>';
-		// print_r($lcs_array);
+		// print_r($fb_post_share_count);
 		// echo '</pre>';
+
 		// $fb_location  = isset( $post_data->location ) ? $post_data->location : '';
 		$fb_embed_vid = isset( $post_data->embed_html ) ? $post_data->embed_html : '';
 		$fb_from_name = isset( $post_data->from->name ) ? $post_data->from->name : '';
@@ -321,7 +322,7 @@ class FTS_Facebook_Feed_Post_Types extends FTS_Facebook_Feed {
 				if ( 'albums' !== $fb_shortcode['type'] ) {
 					echo '<div class="fts-jal-fb-user-thumb">';
 
-					$avatar_id                  = plugin_dir_url( dirname( __FILE__ ) ) . 'images/slick-comment-pic.png';
+					$avatar_id                  = plugin_dir_url( __DIR__ ) . 'images/slick-comment-pic.png';
 					$profile_photo_exists_check = isset( $post_data->fts_profile_pic_url ) && strpos( $post_data->fts_profile_pic_url, 'profilepic' ) !== false ? $post_data->fts_profile_pic_url : $avatar_id;
 
 					echo ( 'reviews' === esc_attr( $fb_shortcode['type'] ) ? '' : '<a href="https://www.facebook.com/' . esc_attr( $from_id_picture ) . '" target="_blank" rel="noreferrer">' ) . '<img border="0" alt="' . ( 'reviews' === esc_attr( $fb_shortcode['type'] ) ? esc_attr( $post_data->reviewer->name ) : esc_attr( $post_data->from->name ) ) . '" src="' . ( 'reviews' === esc_attr( $fb_shortcode['type'] ) ? esc_url( $profile_photo_exists_check ) . '"/>' : 'https://graph.facebook.com/' . esc_attr( $from_id_picture ) ) . ( 'reviews' === esc_attr( $fb_shortcode['type'] ) ? '' : '/picture"/></a>' );
@@ -1095,7 +1096,7 @@ class FTS_Facebook_Feed_Post_Types extends FTS_Facebook_Feed {
 						// User Profile Img.
 						// Not having page public content access persmission anymore is not allowing us to get profile pics anymore, and the link to personal accounts won't work anymore either for people posting to our page.
 						// $avatar_id = isset( $comment->from->id ) ? 'https://graph.facebook.com/'.$comment->from->id.'/picture?redirect=1&type=square' : plugin_dir_url( dirname( __FILE__ ) ) . 'images/slick-comment-pic.png';
-						$avatar_id = plugin_dir_url( dirname( __FILE__ ) ) . 'images/slick-comment-pic.png';
+						$avatar_id = plugin_dir_url( __DIR__ ) . 'images/slick-comment-pic.png';
 						echo '<img class="fts-fb-comment-user-pic" src="' . esc_url( $avatar_id ) . '"/>';
 						echo '<div class="fts-fb-comment-msg">';
 						if ( isset( $comment->from->name ) ) {
@@ -1129,8 +1130,11 @@ class FTS_Facebook_Feed_Post_Types extends FTS_Facebook_Feed {
 			}
 			echo '<div class="fts-jal-fb-top-wrap ' . esc_attr( $hide_date_likes_comments ) . '" style="display:block !important;">';
 			echo '<div class="fts-jal-fb-user-thumb">';
-			echo ( 'reviews' === esc_attr( $fb_shortcode['type'] ) ? '' : '<a href="' . esc_url( 'https://www.facebook.com/' . $from_id_picture ) . '" target="_blank" rel="noreferrer">' ) . '<img border="0" alt="' . ( 'reviews' === esc_attr( $fb_shortcode['type'] ) ? esc_attr( $post_data->reviewer->name ) : esc_attr( $post_data->from->name ) ) . '" src="' . esc_url( 'https://graph.facebook.com/' . ( 'reviews' === esc_attr( $fb_shortcode['type'] ) ? $post_data->reviewer->id : $from_id_picture ) . '/picture' ) . '"/></a>' . ( 'reviews' === $fb_shortcode['type'] ? '' : '</a>' );
-			echo '</div>';
+
+	        $avatar_id                  = plugin_dir_url( __DIR__ ) . 'images/slick-comment-pic.png';
+            $profile_photo_exists_check = isset( $post_data->fts_profile_pic_url ) && strpos( $post_data->fts_profile_pic_url, 'profilepic' ) !== false ? $post_data->fts_profile_pic_url : $avatar_id;
+			echo ( 'reviews' === esc_attr( $fb_shortcode['type'] ) ? '' : '<a href="' . esc_url( 'https://www.facebook.com/' . $from_id_picture ) . '" target="_blank" rel="noreferrer">' ) . '<img border="0" alt="' . ( 'reviews' === esc_attr( $fb_shortcode['type'] ) ? esc_attr( $post_data->reviewer->name ) : esc_attr( $post_data->from->name ) ) . '" src="' . ( 'reviews' === esc_attr( $fb_shortcode['type'] ) ? esc_url( $profile_photo_exists_check ) . '"/>' : 'https://graph.facebook.com/' . esc_attr( $from_id_picture ) ) . ( 'reviews' === esc_attr( $fb_shortcode['type'] ) ? '' : '/picture"/></a>' );
+            echo '</div>';
 
 			// UserName.
 			echo '<span class="fts-jal-fb-user-name"><a href="' . esc_url( 'https://www.facebook.com/' . $from_id_picture ) . '" target="_blank" rel="noreferrer">' . esc_html( $post_data->from->name ) . '</a>' . esc_html( $fb_hide_shared_by_etc_text ) . '</span>';

--- a/feeds/facebook/class-fts-facebook-feed.php
+++ b/feeds/facebook/class-fts-facebook-feed.php
@@ -501,7 +501,7 @@ class FTS_Facebook_Feed extends feed_them_social_functions {
 				} elseif ( isset( $fb_shortcode['slider'] ) && 'yes' !== $fb_shortcode['slider'] && 'yes' === $fb_shortcode['image_stack_animation'] || isset( $fb_shortcode['grid'] ) && 'yes' === $fb_shortcode['grid'] || isset( $fb_shortcode['image_stack_animation'] ) && 'yes' === $fb_shortcode['image_stack_animation'] ) {
 					wp_enqueue_script( 'fts-masonry-pkgd', plugins_url( 'feed-them-social/feeds/js/masonry.pkgd.min.js' ), array( 'jquery' ), FTS_CURRENT_VERSION, false );
 					echo '<script>';
-					echo 'jQuery(window).load(function(){';
+					echo 'jQuery(window).on(\'load\', function(){';
 					echo 'jQuery(".' . esc_js( $fts_dynamic_class_name ) . '").masonry({';
 					echo 'itemSelector: ".fts-jal-single-fb-post"';
 					echo '});';

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: slickremix, slickchris
 Tags: Facebook, Instagram, Twitter, YouTube, Feed
 Requires at least: 3.6.0
-Tested up to: 5.6.0
-Stable tag: 2.9.3
+Tested up to: 5.6.2
+Stable tag: 2.9.4
 License: GPLv2 or later
 
 Display a Custom Facebook feed, Instagram feed, Twitter feed, and YouTube feed on pages, posts or widgets.
@@ -72,6 +72,10 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
   * Log into WordPress dashboard then click **Plugins** > **Add new** > Then under the title "Install Plugins" click **Upload** > **choose the zip** > **Activate the plugin!**
 
 == Changelog ==
+= Version 2.9.4 Tuesday, March 9th, 2021 =
+  * FIX: FACEBOOK FEED: Change .load(function()... call to .on('load', function(). Thanks to @thewebtailors for the fix.
+  * PREMIUM FIX: FACEBOOK FEED: Stray closing a tag for the profile photo when setting show_media=top Also change profile pic call from plugin_dir_url( dirname( __FILE__ ) ) to plugin_dir_url( __DIR__ )
+
 = Version 2.9.3 Wednesday, January 27th, 2021 =
   * FIX: INSTAGRAM & FACEBOOK OPTIONS PAGE: #100 error was returning on tokens even though they were valid. FB changed the error text which resulted in the error message showing up instead of the success message.
   * FIX: GLOBAL OPTIONS: Date Time was not working proper for Instagram if you chose something other than the 'One Day Ago' option. The text Minute or Minutes was not returning either for the 'One Day Ago' option.

--- a/readme.txt
+++ b/readme.txt
@@ -72,9 +72,9 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
   * Log into WordPress dashboard then click **Plugins** > **Add new** > Then under the title "Install Plugins" click **Upload** > **choose the zip** > **Activate the plugin!**
 
 == Changelog ==
-= Version 2.9.4 Tuesday, March 9th, 2021 =
-  * FIX: FACEBOOK FEED: Change .load(function()... call to .on('load', function(). Thanks to @thewebtailors for the fix.
-  * PREMIUM FIX: FACEBOOK FEED: Stray closing a tag for the profile photo when setting show_media=top Also change profile pic call from plugin_dir_url( dirname( __FILE__ ) ) to plugin_dir_url( __DIR__ )
+== Version 2.9.4 Tuesday, March 9th, 2021 =
+   * FIX: FACEBOOK FEED: Change .load(function()... call to .on('load', function(). Thanks to @thewebtailors for the fix.
+   * PREMIUM FIX: FACEBOOK FEED: Stray closing a tag for the profile photo when setting show_media=top Thanks to @thewebtailors for the fix.. Also change profile pic call from plugin_dir_url( dirname( __FILE__ ) ) to plugin_dir_url( __DIR__ )
 
 = Version 2.9.3 Wednesday, January 27th, 2021 =
   * FIX: INSTAGRAM & FACEBOOK OPTIONS PAGE: #100 error was returning on tokens even though they were valid. FB changed the error text which resulted in the error message showing up instead of the success message.


### PR DESCRIPTION
= Version 2.9.4 Tuesday, March 9th, 2021 =
  * FIX: FACEBOOK FEED: Change .load(function()... call to .on('load', function(). Thanks to @thewebtailors for the fix.
  * PREMIUM FIX: FACEBOOK FEED: Stray closing a tag for the profile photo when setting show_media=top Thanks to @thewebtailors for the fix.. Also change profile pic call from plugin_dir_url( dirname( __FILE__ ) ) to plugin_dir_url( __DIR__ )