### PR TITLE
2.9.4

### DIFF
--- a/feed-them.php
+++ b/feed-them.php
@@ -13,7 +13,7 @@
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 4.0.0
- * Tested up to: WordPress 5.6.2
+ * Tested up to: WordPress 5.7.0
  * Stable tag: 2.9.4
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: slickremix, slickchris
 Tags: Facebook, Instagram, Twitter, YouTube, Feed
 Requires at least: 3.6.0
-Tested up to: 5.6.2
+Tested up to: 5.7.0
 Stable tag: 2.9.4
 License: GPLv2 or later
 


### PR DESCRIPTION
== Version 2.9.4 Tuesday, March 9th, 2021 =
   * FIX: FACEBOOK FEED: Change .load(function()... call to .on('load', function(). Thanks to @thewebtailors for the fix.
   * PREMIUM FIX: FACEBOOK FEED: Stray closing a tag for the profile photo when setting show_media=top Thanks to @thewebtailors for the fix.. Also change profile pic call from plugin_dir_url( dirname( __FILE__ ) ) to plugin_dir_url( __DIR__ )