### PR TITLE
2.9.8.1.0

### DIFF
--- a/feed-them.php
+++ b/feed-them.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social - for Twitter feed, Youtube, and more
  * Plugin URI: https://feedthemsocial.com/
  * Description: Display a Custom Facebook feed, Instagram feed, Twitter feed and YouTube feed on pages, posts or widgets.
- * Version: 2.9.8.1
+ * Version: 2.9.8.10
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 4.0.0
  * Tested up to: WordPress 5.9.2
- * Stable tag: 2.9.8.1
+ * Stable tag: 2.9.8.10
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    2.9.8.1
+ * @version    2.9.8.10
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2022 SlickRemix
  *
@@ -31,7 +31,7 @@
  *
  * Makes sure any js or css changes are reloaded properly. Added to enqued css and js files throughout!
  */
-define( 'FTS_CURRENT_VERSION', '2.9.8.1' );
+define( 'FTS_CURRENT_VERSION', '2.9.8.10' );
 
 define( 'FEED_THEM_SOCIAL_NOTICE_STATUS', get_option( 'rating_fts_slick_notice', false ) );
 

--- a/feeds/facebook/class-fts-facebook-feed.php
+++ b/feeds/facebook/class-fts-facebook-feed.php
@@ -2152,7 +2152,7 @@ style="margin:' . ( isset( $fb_shortcode['slider_margin'] ) && '' !== $fb_shortc
                     echo 'if(jQuery(this).scrollTop() + jQuery(this).innerHeight() >= jQuery(this)[0].scrollHeight) {';
                 } else {
                     // this is where we do CLICK function to LOADMORE if  = button in shortcode.
-                    echo 'jQuery("#loadMore_' . esc_js( $fts_dynamic_name ) . '").click(function() {';
+                    echo 'jQuery("#loadMore_' . esc_js( $fts_dynamic_name ) . '").off().click(function() {';
                 }
                 echo 'jQuery("#loadMore_' . esc_js( $fts_dynamic_name ) . '").addClass("fts-fb-spinner");';
                 echo 'var button = jQuery("#loadMore_' . esc_js( $fts_dynamic_name ) . '").html("<div class=\'bounce1\'></div><div class=\'bounce2\'></div><div class=\'bounce3\'></div>");';
@@ -2196,7 +2196,7 @@ style="margin:' . ( isset( $fb_shortcode['slider_margin'] ) && '' !== $fb_shortc
                     }
 
                     echo ' jQuery("#loadMore_' . esc_js( $fts_dynamic_name ) . '").removeAttr("id");';
-                    echo 'jQuery(".' . esc_js( $fts_dynamic_class_name ) . '").unbind("scroll");';
+                    echo 'jQuery(".' . esc_js( $fts_dynamic_class_name ) . '").off("scroll");';
                     echo '}';
                 } else {
                     if ( isset( $fb_shortcode['video_album'] ) && 'yes' === $fb_shortcode['video_album'] ) {
@@ -2214,7 +2214,7 @@ style="margin:' . ( isset( $fb_shortcode['slider_margin'] ) && '' !== $fb_shortc
                         echo 'jQuery("#loadMore_' . esc_js( $fts_dynamic_name ) . '").replaceWith(\'<div class="fts-fb-load-more no-more-posts-fts-fb">' . esc_html( $fb_no_more_posts_text ) . '</div>\');';
                     }
                     echo 'jQuery("#loadMore_' . esc_js( $fts_dynamic_name ) . '").removeAttr("id");';
-                    echo 'jQuery(".' . esc_js( $fts_dynamic_class_name ) . '").unbind("scroll");';
+                    echo 'jQuery(".' . esc_js( $fts_dynamic_class_name ) . '").off("scroll");';
                     echo '}';
 
                 }

--- a/feeds/facebook/class-fts-facebook-feed.php
+++ b/feeds/facebook/class-fts-facebook-feed.php
@@ -2198,7 +2198,9 @@ style="margin:' . ( isset( $fb_shortcode['slider_margin'] ) && '' !== $fb_shortc
                     echo ' jQuery("#loadMore_' . esc_js( $fts_dynamic_name ) . '").removeAttr("id");';
                     echo 'jQuery(".' . esc_js( $fts_dynamic_class_name ) . '").off("scroll");';
                     echo '}';
+
                 } else {
+
                     if ( isset( $fb_shortcode['video_album'] ) && 'yes' === $fb_shortcode['video_album'] ) {
                         echo 'var result = jQuery(data).insertBefore( jQuery("#output_' . esc_js( $fts_dynamic_name ) . '") );';
                         echo 'var result = jQuery(".feed_dynamic_' . esc_js( $fts_dynamic_name ) . '_album_photos").append(data).filter("#output_' . esc_js( $fts_dynamic_name ) . '").html();';

--- a/feeds/instagram/class-fts-instagram-feed.php
+++ b/feeds/instagram/class-fts-instagram-feed.php
@@ -1255,7 +1255,6 @@ if ( isset( $profile_description, $type ) && 'yes' === $profile_description  && 
 
                                    // console.log( jQuery(this).scrollTop() + jQuery(this).innerHeight() );
                                    // console.log( jQuery(this)[0].scrollHeight );
-
                         <?php }
                             else { ?>
                             // If =button in shortcode.

--- a/feeds/instagram/class-fts-instagram-feed.php
+++ b/feeds/instagram/class-fts-instagram-feed.php
@@ -1247,12 +1247,19 @@ if ( isset( $profile_description, $type ) && 'yes' === $profile_description  && 
                         // $scroll_more = load_more_posts_style shortcode att.
                         if ( 'autoscroll' === $scroll_more ) { // this is where we do SCROLL function to LOADMORE if = autoscroll in shortcode.
                             ?>
-                        jQuery(".<?php echo esc_js( $fts_dynamic_class_name ); ?>instagram").bind("scroll", function () {
-                            if (jQuery(this).scrollTop() + jQuery(this).innerHeight() >= jQuery(this)[0].scrollHeight) {
-                                <?php
-                        } else { // this is where we do CLICK function to LOADMORE if = button in shortcode.
-                            ?>
-                                jQuery("#loadMore_<?php echo esc_js( $fts_dynamic_name ); ?>").click(function () {
+
+                            // If =autoscroll in shortcode.
+                            jQuery(".<?php echo esc_js( $fts_dynamic_class_name ) ?>instagram").bind("scroll",function() {
+
+                                if( jQuery(this).scrollTop() + jQuery(this).innerHeight() >= jQuery(this)[0].scrollHeight ) {
+
+                                   // console.log( jQuery(this).scrollTop() + jQuery(this).innerHeight() );
+                                   // console.log( jQuery(this)[0].scrollHeight );
+
+                        <?php }
+                            else { ?>
+                            // If =button in shortcode.
+                                jQuery("#loadMore_<?php echo esc_js( $fts_dynamic_name ); ?>").off().click(function() {
                         <?php } ?>
                                     jQuery("#loadMore_<?php echo esc_js( $fts_dynamic_name ); ?>").addClass('fts-fb-spinner');
                                     var button = jQuery('#loadMore_<?php echo esc_js( $fts_dynamic_name ); ?>').html('<div class="bounce1"></div><div class="bounce2"></div><div class="bounce3"></div>');
@@ -1282,10 +1289,10 @@ if ( isset( $profile_description, $type ) && 'yes' === $profile_description  && 
                                         success: function (data) {
                                             console.log('Well Done and got this from sever: ' + data);
                                             jQuery('.<?php echo esc_js( $fts_dynamic_class_name ); ?>').append(data).filter('.<?php echo esc_js( $fts_dynamic_class_name ); ?>').html();
-                                            if (!nextURL_<?php echo esc_js( sanitize_key( $_REQUEST['fts_dynamic_name'] ) ); ?> || nextURL_<?php echo esc_js( sanitize_key( $_REQUEST['fts_dynamic_name'] ) ); ?> === 'no more') {
+                                            if (!nextURL_<?php echo esc_js( sanitize_key( $_REQUEST['fts_dynamic_name'] ) ); ?> || 'no more' === nextURL_<?php echo esc_js( sanitize_key( $_REQUEST['fts_dynamic_name'] ) ); ?> ) {
                                                 jQuery('#loadMore_<?php echo esc_js( $fts_dynamic_name ); ?>').replaceWith('<div class="fts-fb-load-more no-more-posts-fts-fb"><?php echo esc_js( $instagram_no_more_photos_text ); ?></div>');
                                                 jQuery('#loadMore_<?php echo esc_js( $fts_dynamic_name ); ?>').removeAttr('id');
-                                                jQuery(".<?php echo esc_js( $fts_dynamic_class_name ); ?>instagram").unbind('scroll');
+                                                jQuery(".<?php echo esc_js( $fts_dynamic_class_name ); ?>instagram").off('scroll');
                                             }
                                             jQuery('#loadMore_<?php echo esc_js( $fts_dynamic_name ); ?>').html('<?php echo esc_js( $instagram_load_more_text ); ?>');
                                             jQuery("#loadMore_<?php echo esc_js( $fts_dynamic_name ); ?>").removeClass('fts-fb-spinner');
@@ -1297,18 +1304,18 @@ if ( isset( $profile_description, $type ) && 'yes' === $profile_description  && 
                                             slickremixImageResizing(); // Reload our imagesizing function so the images show up proper
                                         }
                                     }); // end of ajax()
-                                    return false;
-                                    <?php
-                                    // string $scroll_more is at top of this js script. exception for scroll option closing tag.
-                                    if ( 'autoscroll' === $scroll_more ) {
-                                        ?>
-                                }; // end of scroll ajax load
-                                <?php } ?>
-                            }
-                        ); // end of document.ready
-                    }); // end of form.submit </script>
-                        <?php
-                    }//End Check.
+                                     return false;
+                            // string $scrollMore is at top of this js script. exception for scroll option closing tag.
+                            <?php if ( 'autoscroll' === $loadmore ) { ?>
+                                    };
+                                }); // end of scroll ajax load.
+                            <?php } else { ?>
+                                }); // end of click button.
+                            <?php } ?>
+						}); // end of document.ready.
+                    </script><?php
+
+					}//End Check.
                 }
             }
 			// main closing div not included in ajax check so we can close the wrap at all times.

--- a/feeds/twitter/class-fts-twitter-feed.php
+++ b/feeds/twitter/class-fts-twitter-feed.php
@@ -1454,7 +1454,6 @@ class FTS_Twitter_Feed extends feed_them_social_functions {
 										jQuery(".fts-slicker-twitter-posts").masonry("layout");
 									}, 500);
 									<?php } ?>
-
 								}
 							 });// end of ajax().
                             return false;

--- a/feeds/twitter/class-fts-twitter-feed.php
+++ b/feeds/twitter/class-fts-twitter-feed.php
@@ -1389,12 +1389,12 @@ class FTS_Twitter_Feed extends feed_them_social_functions {
 				if ( 'autoscroll' === $scroll_more ) { // this is where we do SCROLL function to LOADMORE if = autoscroll in shortcode.
 					?>
 				jQuery(".<?php echo esc_js( $fts_dynamic_class_name ); ?>").bind("scroll", function () {
-					if (jQuery(this).scrollTop() + jQuery(this).innerHeight() >= jQuery(this)[0].scrollHeight) {
+					if ( jQuery(this).scrollTop() + jQuery(this).innerHeight() >= jQuery(this)[0].scrollHeight ) {
 						<?php
 				} else {
 					// this is where we do CLICK function to LOADMORE if = button in shortcode!
 					?>
-						jQuery("#loadMore_<?php echo esc_js( $fts_dynamic_name ); ?>").click(function () {
+						jQuery("#loadMore_<?php echo esc_js( $fts_dynamic_name ); ?>").off().click(function () {
 				<?php } ?>
 							jQuery("#loadMore_<?php echo esc_js( $fts_dynamic_name ); ?>").addClass('fts-fb-spinner');
 							var button = jQuery('#loadMore_<?php echo esc_js( $fts_dynamic_name ); ?>').html('<div class="bounce1"></div><div class="bounce2"></div><div class="bounce3"></div>');
@@ -1431,10 +1431,10 @@ class FTS_Twitter_Feed extends feed_them_social_functions {
 									jQuery('.<?php echo esc_js( $fts_dynamic_class_name ); ?>').append(data).filter('.<?php echo esc_js( $fts_dynamic_class_name ); ?>').html();
 									<?php } ?>
 
-									if (!maxID_<?php echo sanitize_text_field( wp_unslash( $_REQUEST['fts_dynamic_name'] ) ); ?> || maxID_<?php echo esc_js( sanitize_text_field( wp_unslash( $_REQUEST['fts_dynamic_name'] ) ) ); ?> == 'no more') {
+									if (!maxID_<?php echo sanitize_text_field( wp_unslash( $_REQUEST['fts_dynamic_name'] ) ); ?> || 'no more' === maxID_<?php echo esc_js( sanitize_text_field( wp_unslash( $_REQUEST['fts_dynamic_name'] ) ) ); ?>) {
 										jQuery('#loadMore_<?php echo esc_js( $fts_dynamic_name ); ?>').replaceWith('<div class="fts-fb-load-more no-more-posts-fts-fb"><?php echo esc_js( $twitter_no_more_tweets_text ); ?></div>');
 										jQuery('#loadMore_<?php echo esc_js( $fts_dynamic_name ); ?>').removeAttr('id');
-										jQuery(".<?php echo esc_js( $fts_dynamic_class_name ); ?>").unbind('scroll');
+										jQuery(".<?php echo esc_js( $fts_dynamic_class_name ); ?>").off('scroll');
 									}
 									jQuery('#loadMore_<?php echo esc_js( $fts_dynamic_name ); ?>').html('<?php echo esc_js( $twitter_load_more_text ); ?>');
 									//	jQuery('#loadMore_< ?php echo $fts_dynamic_name ?>').removeClass('flip360-fts-load-more');
@@ -1456,16 +1456,15 @@ class FTS_Twitter_Feed extends feed_them_social_functions {
 									<?php } ?>
 
 								}
-							}); // end of ajax()
-							return false;
-									<?php
-									// string $scroll_more is at top of this js script. acception for scroll option closing tag.
-									if ( 'autoscroll' === $scroll_more ) {
-										?>
-						}; // end of scroll ajax load.
-								<?php } ?>
-					}
-				); // end of form.submit
+							 });// end of ajax().
+                            return false;
+                    // string $scrollMore is at top of this js script. exception for scroll option closing tag.
+                    <?php if ( 'autoscroll' === $loadmore ) { ?>
+                            };
+                        }); // end of scroll ajax load.
+                    <?php } else { ?>
+                        }); // end of click button.
+                    <?php } ?>
 						<?php
 						if ( isset( $grid ) && 'yes' === $grid ) {
 							?>

--- a/feeds/youtube/class-youtube-feed-free.php
+++ b/feeds/youtube/class-youtube-feed-free.php
@@ -992,5 +992,4 @@ class FTS_Youtube_Feed_Free extends feed_them_social_functions {
 
 		return $random_string;
 	}
-
 }

--- a/includes/feed-them-functions.php
+++ b/includes/feed-them-functions.php
@@ -613,8 +613,6 @@ class feed_them_social_functions {
 															jQuery('.fb-sublist-page-id-<?php echo esc_js( $fb_page_id ); ?>').append(data).filter('.fb-sublist-page-id-<?php echo esc_js( $fb_page_id ); ?>').html();
 															jQuery('.fb-sublist-page-id-<?php echo esc_js( $fb_page_id ); ?>').animate({scrollTop: '+=100px'}, 800); // scroll down a 100px after new items are added
 
-
-
 															<?php if ( isset( $data->locations->paging->next ) && $data->locations->paging->next === $_REQUEST['next_location_url'] ) { ?>
 															jQuery('#loadMore_<?php echo esc_js( $fb_page_id ); ?>_location').replaceWith('<div class="fts-fb-load-more no-more-posts-fts-fb fts-no-more-locations-<?php echo esc_js( $fb_page_id ); ?>" style="background:none !important"><?php echo esc_html( 'All Locations loaded', 'feed-them-social' ); ?></div>');
 															jQuery('#loadMore_<?php echo esc_js( $fb_page_id ); ?>_location').removeAttr('id');

--- a/readme.txt
+++ b/readme.txt
@@ -72,14 +72,14 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
   * Log into WordPress dashboard then click **Plugins** > **Add new** > Then under the title "Install Plugins" click **Upload** > **choose the zip** > **Activate the plugin!**
 
 == Changelog ==
-= Version 2.9.8.1 Thursday, April 14th, 2022 =
+= Version 2.9.8.1 Friday, April 15th, 2022 =
   * NEW: Instagram Basic Feed: Access Token. As long as an Instagram User does not change their password then the Instagram Basic token will automatically refresh after 7 days. This will resolve a long standing issue where users would have to get a new token every 60 days. This option will only work if the access token is not in the shortcode. FTS 3.0 will be released soon and the process to create a feed will be amazingly simple and will address the access token in shortcode.
   * NEW: Instagram and YouTube Feeds: Even if token fails and the cache is deleted the feed will still be visible.
   * NEW: YouTube Options: Access Token Refresh.
-  * FIX: Premium: YouTube Feed: Depreciated jquery call for bind. This caused issue with autoscroll loadmore option.
   * FIX: YouTube: Access Token Refresh.
   * FIX: Misc Styles and general options text.
   * FIX: Twitter options: Remove the create your own Twitter Keys options. Twitter APPs must now be approved and the process is not so simple. It's better to use the Access Token Option for a quicker setup.
+  * FIX: Premium: All Feeds: Depreciated jQuery call for .bind(), now .off(). This caused issue with autoscroll loadmore option on YouTube Specifically.
   * NOTE: Tested with WordPress Version 5.9.3
 
 = Version 2.9.8 Thursday, March 17th, 2022 =

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: slickremix, slickchris
 Tags: Facebook, Instagram, Twitter, YouTube, Feed
 Requires at least: 3.6.0
 Tested up to: 5.9.3
-Stable tag: 2.9.8.1
+Stable tag: 2.9.8.10
 License: GPLv2 or later
 
 Display a Custom Facebook feed, Instagram feed, Twitter feed, and YouTube feed on pages, posts or widgets.
@@ -72,7 +72,7 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
   * Log into WordPress dashboard then click **Plugins** > **Add new** > Then under the title "Install Plugins" click **Upload** > **choose the zip** > **Activate the plugin!**
 
 == Changelog ==
-= Version 2.9.8.1 Friday, April 15th, 2022 =
+= Version 2.9.8.10 Friday, April 15th, 2022 =
   * NEW: Instagram Basic Feed: Access Token. As long as an Instagram User does not change their password then the Instagram Basic token will automatically refresh after 7 days. This will resolve a long standing issue where users would have to get a new token every 60 days. This option will only work if the access token is not in the shortcode. FTS 3.0 will be released soon and the process to create a feed will be amazingly simple and will address the access token in shortcode.
   * NEW: Instagram and YouTube Feeds: Even if token fails and the cache is deleted the feed will still be visible.
   * NEW: YouTube Options: Access Token Refresh.


### PR DESCRIPTION
= Version 2.9.8.10 Friday, April 15th, 2022 =
  * NEW: Instagram Basic Feed: Access Token. As long as an Instagram User does not change their password then the Instagram Basic token will automatically refresh after 7 days. This will resolve a long standing issue where users would have to get a new token every 60 days. This option will only work if the access token is not in the shortcode. FTS 3.0 will be released soon and the process to create a feed will be amazingly simple and will address the access token in shortcode.
  * NEW: Instagram and YouTube Feeds: Even if token fails and the cache is deleted the feed will still be visible.
  * NEW: YouTube Options: Access Token Refresh.
  * FIX: YouTube: Access Token Refresh.
  * FIX: Misc Styles and general options text.
  * FIX: Twitter options: Remove the create your own Twitter Keys options. Twitter APPs must now be approved and the process is not so simple. It's better to use the Access Token Option for a quicker setup.
  * FIX: Premium: All Feeds: Depreciated jQuery call for .bind(), now .off(). This caused issue with autoscroll loadmore option on YouTube Specifically.
  * NOTE: Tested with WordPress Version 5.9.3