### PR TITLE
2.9.8.2

### DIFF
--- a/feed-them.php
+++ b/feed-them.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social - for Twitter feed, Youtube, and more
  * Plugin URI: https://feedthemsocial.com/
  * Description: Display a Custom Facebook feed, Instagram feed, Twitter feed and YouTube feed on pages, posts or widgets.
- * Version: 2.9.8.10
+ * Version: 2.9.8.2
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 4.0.0
- * Tested up to: WordPress 5.9.2
- * Stable tag: 2.9.8.10
+ * Tested up to: WordPress 5.9.3
+ * Stable tag: 2.9.8.2
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    2.9.8.10
+ * @version    2.9.8.2
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2022 SlickRemix
  *
@@ -31,7 +31,7 @@
  *
  * Makes sure any js or css changes are reloaded properly. Added to enqued css and js files throughout!
  */
-define( 'FTS_CURRENT_VERSION', '2.9.8.10' );
+define( 'FTS_CURRENT_VERSION', '2.9.8.2' );
 
 define( 'FEED_THEM_SOCIAL_NOTICE_STATUS', get_option( 'rating_fts_slick_notice', false ) );
 

--- a/includes/feed-them-functions.php
+++ b/includes/feed-them-functions.php
@@ -3990,7 +3990,10 @@ if ( ! empty( $youtube_loadmore_text_color ) ) {
             $instagram_basic = json_decode( $instagram_basic_response['data'] );
 
             if ( !empty( $instagram_basic->data ) ) {
-                $access_token = $this->data_protection->decrypt( get_option( 'fts_instagram_custom_api_token' ) );
+
+                $parts = parse_url($api_url);
+                parse_str( $parts['query'], $query);
+                $access_token = false !== $this->data_protection->decrypt(  $query['access_token'] ) ? $this->data_protection->decrypt(  $query['access_token'] ) :  $query['access_token'];
 
                 // We loop through the media ids from the above $instagram_basic_data_array['data'] and request the info for each to create an array we can cache.
                 $instagram_basic_output = (object)['data' => []];

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: slickremix, slickchris
 Tags: Facebook, Instagram, Twitter, YouTube, Feed
 Requires at least: 3.6.0
 Tested up to: 5.9.3
-Stable tag: 2.9.8.10
+Stable tag: 2.9.8.2
 License: GPLv2 or later
 
 Display a Custom Facebook feed, Instagram feed, Twitter feed, and YouTube feed on pages, posts or widgets.
@@ -72,6 +72,9 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
   * Log into WordPress dashboard then click **Plugins** > **Add new** > Then under the title "Install Plugins" click **Upload** > **choose the zip** > **Activate the plugin!**
 
 == Changelog ==
+= Version 2.9.8.2 Friday, April 22nd, 2022 =
+ * FIX: Instagram Basic Feed: If access token on options page did not match the one in shortcode the feed would not display properly.
+
 = Version 2.9.8.10 Friday, April 15th, 2022 =
   * NEW: Instagram Basic Feed: Access Token. As long as an Instagram User does not change their password then the Instagram Basic token will automatically refresh after 7 days. This will resolve a long standing issue where users would have to get a new token every 60 days. This option will only work if the access token is not in the shortcode. FTS 3.0 will be released soon and the process to create a feed will be amazingly simple and will address the access token in shortcode.
   * NEW: Instagram and YouTube Feeds: Even if token fails and the cache is deleted the feed will still be visible.


### PR DESCRIPTION
= Version 2.9.8.2 Friday, April 22nd, 2022 =
 * FIX: Instagram Basic Feed: If access token on options page did not match the one in shortcode the feed would not display properly.