### PR TITLE
3.0.1

### DIFF
--- a/admin/class-fts-facebook-options-page.php
+++ b/admin/class-fts-facebook-options-page.php
@@ -231,7 +231,6 @@ class FTS_Facebook_Options_Page {
 								// Echo our shortcode for the page token list with loadmore button
 								// These functions are on feed-them-functions.php!
 								echo do_shortcode( '[fts_fb_page_token]' );
-
 							}
 							?>
 						</div>

--- a/admin/class-fts-instagram-options-page.php
+++ b/admin/class-fts-instagram-options-page.php
@@ -154,7 +154,11 @@ class FTS_Instagram_Options_Page {
 
                     <div class="feed-them-social-admin-input-wrap"  style="margin-bottom:0px;
                     <?php
-                    if ( 'no' === $debug ) {
+
+
+                    $debug = 'no';
+
+                    if ( 'yes' === $debug ) {
                         ?>
                             display:none<?php } ?>">
                         <div class="feed-them-social-admin-input-label fts-instagram-border-bottom-color-label">
@@ -215,8 +219,7 @@ class FTS_Instagram_Options_Page {
                     // We get 60 days to refresh the token, if it's not refreshed before then it will expire.
                     $expiration_time = '' !== get_option( 'fts_instagram_custom_api_token_expires_in' ) ? get_option( 'fts_instagram_custom_api_token_expires_in' ) : '';
 
-
-					if ( time() < $expiration_time  && 'yes' === $debug ) {
+					if ( time() < $expiration_time  && isset( $debug ) && 'yes' === $debug ) {
 						?>
 						<script>
 

--- a/feed-them.php
+++ b/feed-them.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social - for Twitter feed, Youtube, and more
  * Plugin URI: https://feedthemsocial.com/
  * Description: Display a Custom Facebook feed, Instagram feed, Twitter feed and YouTube feed on pages, posts or widgets.
- * Version: 3.0.0
+ * Version: 3.0.1
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 4.0.0
  * Tested up to: WordPress 6.0.1
- * Stable tag: 3.0.0
+ * Stable tag: 3.0.1
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    3.0.0
+ * @version    3.0.1
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2022 SlickRemix
  *
@@ -31,7 +31,7 @@
  *
  * Makes sure any js or css changes are reloaded properly. Added to enqued css and js files throughout!
  */
-define( 'FTS_CURRENT_VERSION', '3.0.0' );
+define( 'FTS_CURRENT_VERSION', '3.0.1' );
 
 define( 'FEED_THEM_SOCIAL_NOTICE_STATUS', get_option( 'rating_fts_slick_notice', false ) );
 

--- a/feed-them.php
+++ b/feed-them.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social - for Twitter feed, Youtube, and more
  * Plugin URI: https://feedthemsocial.com/
  * Description: Display a Custom Facebook feed, Instagram feed, Twitter feed and YouTube feed on pages, posts or widgets.
- * Version: 2.9.9
+ * Version: 3.0.0
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 4.0.0
  * Tested up to: WordPress 6.0.1
- * Stable tag: 2.9.9
+ * Stable tag: 3.0.0
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    2.9.9
+ * @version    3.0.0
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2022 SlickRemix
  *
@@ -31,7 +31,7 @@
  *
  * Makes sure any js or css changes are reloaded properly. Added to enqued css and js files throughout!
  */
-define( 'FTS_CURRENT_VERSION', '2.9.9' );
+define( 'FTS_CURRENT_VERSION', '3.0.0' );
 
 define( 'FEED_THEM_SOCIAL_NOTICE_STATUS', get_option( 'rating_fts_slick_notice', false ) );
 
@@ -174,7 +174,7 @@ final class Feed_Them_Social {
         if ( get_transient( 'fts_updated' ) ) {
             echo '<div class="notice notice-success updated is-dismissible">';
             echo sprintf(
-                    esc_html__( '%10$sThanks for updating Feed Them Social. We have deleted the cache in our plugin so you can view any changes we have made.%11$s %8$s%6$sNOTE%7$s: Feed Them Social 3.0 will have some amazing changes in the coming months. Please take a moment and %4$s read them here%5$s.%9$s', 'feed-them-social' ),
+                    esc_html__( '%10$sThanks for updating Feed Them Social. We have deleted the cache in our plugin so you can view any changes we have made.%11$s %8$s%6$sNOTE%7$s: Feed Them Social will have some amazing changes in the coming months. Please take a moment and %4$s read them here%5$s.%9$s', 'feed-them-social' ),
                     '<a href="' . esc_url( 'admin.php?page=feed-them-settings-page' ) . '">',
                     '</a>',
                     '<br/><br/>',

--- a/feeds/instagram/class-fts-instagram-feed.php
+++ b/feeds/instagram/class-fts-instagram-feed.php
@@ -384,15 +384,6 @@ class FTS_Instagram_Feed extends feed_them_social_functions {
 				}
 			}
 
-
-
-
-
-
-
-
-
-
 			wp_enqueue_script( 'fts-global', plugins_url( 'feed-them-social/feeds/js/fts-global.js' ), array( 'jquery' ), FTS_CURRENT_VERSION, false );
 			$instagram_data_array = array();
 

--- a/includes/feed-them-functions.php
+++ b/includes/feed-them-functions.php
@@ -430,8 +430,7 @@ class feed_them_social_functions {
                 $fb_token_response          = isset( $_REQUEST['next_url'] ) ? wp_remote_fopen( esc_url_raw( $_REQUEST['next_url'] ) ) : $fb_url;
                 $test_fb_app_token_response = json_decode( $fb_token_response );
 
-                // Test.
-                //print_r( $test_fb_app_token_response );
+                // Test. print_r( $test_fb_app_token_response );
 
 				$_REQUEST['next_url']       = isset( $test_fb_app_token_response->paging->next ) ? esc_url_raw( $test_fb_app_token_response->paging->next ) : '';
 			} else {
@@ -3585,6 +3584,7 @@ if ( ! empty( $youtube_loadmore_text_color ) ) {
             $start_of_time_final = false !== $startoftime ? sanitize_key( $startoftime ) : '';
             update_option( 'fts_instagram_custom_api_token_expires_in', sanitize_text_field( wp_unslash( $start_of_time_final ) ) );
 
+            // Only being output to console.log so we can see confirmation.
             echo sanitize_text_field( $_REQUEST['expires_in'] );
             echo '<br/>';
         }
@@ -3595,6 +3595,7 @@ if ( ! empty( $youtube_loadmore_text_color ) ) {
             // $output .= do_shortcode('[fts _youtube vid_count=3 large_vid=no large_vid_title=no large_vid_description=no thumbs_play_in_iframe=popup vids_in_row=3 space_between_videos=1px force_columns=yes maxres_thumbnail_images=yes thumbs_wrap_color=#000 wrap=none video_wrap_display=none comments_count=12 channel_id=UCqhnX4jA0A5paNd1v-zEysw loadmore=button loadmore_count=5 loadmore_btn_maxwidth=300px loadmore_btn_margin=10px]');
         }
 
+        // Only being output to console.log so we can see confirmation.
         echo sanitize_text_field( $_REQUEST['access_token'] );
 
         wp_die();

--- a/includes/feed-them-functions.php
+++ b/includes/feed-them-functions.php
@@ -422,7 +422,7 @@ class feed_them_social_functions {
                 // SRL 4-23-22. For now we are just going to check for error, if error then that would mean the first object in array is a new page experience.
                 // if is new page has_transitioned_to_new_page_experience => 1 This could be expanded in the future by creating a foreach loops to check each page
                 // but then you have to run a call for each page and that seems like overkill if you have hundreds of pages. FB should come up with a simpler way.
-                if( $test_fb_app_token_response->error ){
+                if( !empty( $test_fb_app_token_response->error  ) ){
                     // Possibly the user is on a new page experience so let's run the call without locations.
                     $fb_url = 'fts-facebook-feed-styles-submenu-page' === $_GET['page'] ? wp_remote_fopen( 'https://graph.facebook.com/me/accounts?fields=has_transitioned_to_new_page_experience,name,id,link,access_token&access_token=' . $_GET['code'] . '&limit=500' ) : wp_remote_fopen( 'https://graph.facebook.com/me/accounts?fields=has_transitioned_to_new_page_experience,instagram_business_account{id,username,profile_picture_url},name,id,link,access_token&access_token=' . $_GET['code'] . '&limit=500' );
 
@@ -3585,13 +3585,13 @@ if ( ! empty( $youtube_loadmore_text_color ) ) {
             $start_of_time_final = false !== $startoftime ? sanitize_key( $startoftime ) : '';
             update_option( 'fts_instagram_custom_api_token_expires_in', sanitize_text_field( wp_unslash( $start_of_time_final ) ) );
 
-            echo wp_unslash(  $_REQUEST['expires_in'] );
+            echo sanitize_text_field( $_REQUEST['expires_in'] );
             echo '<br/>';
         }
 
         // This only happens if the token is expired on the YouTube Options page and you go to re-save or refresh the page for some reason. It will also run this function if the cache is emptied and the token is found to be expired.
         if ( 'no' === $_REQUEST['button_pushed'] ) {
-            echo 'Token Refreshed: ';
+            echo esc_html( 'Token Refreshed: ' );
             // $output .= do_shortcode('[fts _youtube vid_count=3 large_vid=no large_vid_title=no large_vid_description=no thumbs_play_in_iframe=popup vids_in_row=3 space_between_videos=1px force_columns=yes maxres_thumbnail_images=yes thumbs_wrap_color=#000 wrap=none video_wrap_display=none comments_count=12 channel_id=UCqhnX4jA0A5paNd1v-zEysw loadmore=button loadmore_count=5 loadmore_btn_maxwidth=300px loadmore_btn_margin=10px]');
         }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: slickremix, slickchris
 Tags: Facebook, Instagram, Twitter, YouTube, Feed
 Requires at least: 3.6.0
 Tested up to: 6.0.1
-Stable tag: 3.0.0
+Stable tag: 3.0.1
 License: GPLv2 or later
 
 Display a Custom Facebook feed, Instagram feed, Twitter feed, and YouTube feed on pages, posts or widgets.
@@ -72,12 +72,12 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
   * Log into WordPress dashboard then click **Plugins** > **Add new** > Then under the title "Install Plugins" click **Upload** > **choose the zip** > **Activate the plugin!**
 
 == Changelog ==
-= Version 3.0.0 Wednesday, July 13th, 2022 =
+= Version 3.0.1 Wednesday, July 13th, 2022 =
  * FIX: Facebook Options Page: notice if $test_fb_app_token_response->error was empty.
  * FIX: Sanitize output of expires_in from fts_refresh_token_ajax function.
 
 = Version 2.9.9 Tuesday, July 12th, 2022 =
- * FIX: Sanitize output of access token from fts_refresh_token_ajax function.
+ * FIX: Sanitize output of access_token from fts_refresh_token_ajax function.
 
 = Version 2.9.8.6 Monday, July 11th, 2022 =
  * FIX: Facebook Feed: Share option was throwing invalid APP ID error.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: slickremix, slickchris
 Tags: Facebook, Instagram, Twitter, YouTube, Feed
 Requires at least: 3.6.0
 Tested up to: 6.0.1
-Stable tag: 2.9.9
+Stable tag: 3.0.0
 License: GPLv2 or later
 
 Display a Custom Facebook feed, Instagram feed, Twitter feed, and YouTube feed on pages, posts or widgets.
@@ -72,6 +72,10 @@ Feed Them Social was Developed By SlickRemix --> [https://www.slickremix.com/](h
   * Log into WordPress dashboard then click **Plugins** > **Add new** > Then under the title "Install Plugins" click **Upload** > **choose the zip** > **Activate the plugin!**
 
 == Changelog ==
+= Version 3.0.0 Wednesday, July 13th, 2022 =
+ * FIX: Facebook Options Page: notice if $test_fb_app_token_response->error was empty.
+ * FIX: Sanitize output of expires_in from fts_refresh_token_ajax function.
+
 = Version 2.9.9 Tuesday, July 12th, 2022 =
  * FIX: Sanitize output of access token from fts_refresh_token_ajax function.
 


### PR DESCRIPTION
= Version 3.0.1 Wednesday, July 13th, 2022 =
 * FIX: Facebook Options Page: notice if $test_fb_app_token_response->error was empty.
 * FIX: Sanitize output of expires_in from fts_refresh_token_ajax function.