### PR TITLE
Fix PHP warnings

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -119,7 +119,7 @@ Log into WordPress dashboard then click **Plugins** > **Add new** > Then under t
 = Version 4.0.6 Thursday, March 9th, 2023 =
   * FIX: Facebook Feed: PHP warnings for position of social icon. Thanks to @thewebtailors for fixing this.
   * FIX: Twitter Feed: PHP warnings for popup. Thanks to @ericbourges for letting us know about this.
-  * FIX: SMTP issue by removing pluggable call in feeds-cpt-class.php
+  * FIX: SMTP issue by removing pluggable call in feeds-cpt-class.php Thank you @pixelshrink & @kenrichman for letting us know about this.
   * FIX: Depreciated warnings in updater-check-class.php and updater-check-init.php. Thanks to @jpniekamp for bringing this to our attention.
 
 = Version 4.0.5 Wednesday, March 8th, 2023 =


### PR DESCRIPTION
= Version 4.0.6 Thursday, March 9th, 2023 =
  * FIX: Facebook Feed: PHP warnings for position of social icon. Thanks to @thewebtailors for fixing this.
  * FIX: Twitter Feed: PHP warnings for popup. Thanks to @ericbourges for letting us know about this.
  * FIX: SMTP issue by removing pluggable call in feeds-cpt-class.php Thank you @pixelshrink & @kenrichman for letting us know about this.
  * FIX: Depreciated warnings in updater-check-class.php and updater-check-init.php. Thanks to @jpniekamp for bringing this to our attention.