### PR TITLE
PHP 7-7.2 trailing comma incompatibility, remove safe_mode depreciate…

### DIFF
--- a/admin/cpt/options/feeds-cpt-options.php
+++ b/admin/cpt/options/feeds-cpt-options.php
@@ -206,7 +206,7 @@ class Feed_CPT_Options {
                         '<svg xmlns="http://www.w3.org/2000/svg" class="fts-info-icon" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.2.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0S0 114.6 0 256S114.6 512 256 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-144c-17.7 0-32-14.3-32-32s14.3-32 32-32s32 14.3 32 32s-14.3 32-32 32z"/></svg><div class="fts-select-social-network-menu-instructions">',
                         '</div>',
                         '<strong>',
-                        '</strong>',
+                        '</strong>'
 
                     ),
 

--- a/admin/system-info.php
+++ b/admin/system-info.php
@@ -142,7 +142,6 @@ $my_request = stripslashes_deep( $_SERVER );
 Web Server Info: <?php echo esc_html( $my_request['SERVER_SOFTWARE'] ) . "\n"; ?>
 
 -- PHP Configuration:
-Safe Mode: <?php echo esc_html( ini_get( 'safe_mode' ) ? 'Yes' : "No\n" ); ?>
 Upload Max Size: <?php echo esc_html( ini_get( 'upload_max_filesize' ) . "\n" ); ?>
 Post Max Size: <?php echo esc_html( ini_get( 'post_max_size' ) . "\n" ); ?>
 Upload Max Filesize: <?php echo esc_html( ini_get( 'upload_max_filesize' ) . "\n" ); ?>

--- a/metabox/metabox-functions-class.php
+++ b/metabox/metabox-functions-class.php
@@ -810,7 +810,7 @@ class Metabox_Functions {
                                     $option_name,
                                     $option_id,
                                     isset( $option['class'] ) ? ' ' . $option['class'] : '',
-                                    isset( $multiple ) ? $multiple : '',
+                                    isset( $multiple ) ? $multiple : ''
                                 );
 
                                 $lang_options_array = json_decode( $this->feed_functions->xml_json_parse( 'https://raw.githubusercontent.com/pennersr/django-allauth/master/allauth/socialaccount/providers/facebook/data/FacebookLocales.xml' ) );

--- a/readme.txt
+++ b/readme.txt
@@ -116,8 +116,9 @@ Log into WordPress dashboard then click **Plugins** > **Add new** > Then under t
 16. Add the shortcode you generated from the settings page to any post, page, or text widget.
 
 == Changelog ==
-= Version 4.0.7 Tuesday, March 13th, 2023 =
+= Version 4.0.7 Tuesday, March 14th, 2023 =
   * FIX: Carousel Feed: Script not loading.
+  * FIX: PHP: Trailing commas making it impossible to load the plugin in vs 7.0-7.2. Depreciated safe_mode call for System Info details.
 
 = Version 4.0.6 Thursday, March 9th, 2023 =
   * FIX: Facebook Feed: PHP warnings for position of social icon. Thanks to @thewebtailors for fixing this.


### PR DESCRIPTION
== Changelog ==
= Version 4.0.7 Tuesday, March 14th, 2023 =
  * FIX: Carousel Feed: Script not loading.
  * FIX: PHP: Trailing commas making it impossible to load the plugin in vs 7.0-7.2. Depreciated safe_mode call for System Info details.
