### PR TITLE
4.0.9

### DIFF
--- a/admin/cpt/access-tokens/single/instagram-access-token.php
+++ b/admin/cpt/access-tokens/single/instagram-access-token.php
@@ -100,7 +100,12 @@ class Instagram_Access_Functions {
                     var code              = url.searchParams.get("code");
                     var feed_type         = url.searchParams.get("feed_type");
                     var user_id           = url.searchParams.get("user_id");
-                    var expires_in_check  = url.searchParams.get("expires_in") - 4579200;
+
+                     /* Testing
+                     1677574786979 get today's timestamp and add some seconds to it so we can test.
+                     var expires_in_check  = 1677574786979 + 5173728; */
+
+                     var expires_in_check  = url.searchParams.get("expires_in") - 432000;
 
                     if( undefined!== cpt_id && undefined!== feed_type && 'instagram_basic' === feed_type ) {
 
@@ -114,9 +119,7 @@ class Instagram_Access_Functions {
                         $('#fts_instagram_custom_api_token_expires_in').val('');
                         $('#fts_instagram_custom_api_token_expires_in').val( $('#fts_instagram_custom_api_token_expires_in').val() + date );
 
-
                         // Take the code param from url and pass it to our encrypt function to sanitize and save to db then save all the options.
-
                         const codeArray = {
                             "feed_type" : 'instagram_basic',
                             "user_id" : user_id,

--- a/feed-them-social.php
+++ b/feed-them-social.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social - Page, Post, Video and Photo Galleries
  * Plugin URI: https://feedthemsocial.com/
  * Description: Custom feeds for Instagram, Facebook Pages, Album Photos, Videos & Covers, Twitter & YouTube on pages, posts or widgets.
- * Version: 4.0.81
+ * Version: 4.0.9
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /includes/languages
  * Requires at least: WordPress 5.4
  * Tested up to: WordPress 6.2
- * Stable tag: 4.0.81
+ * Stable tag: 4.0.9
  * License: GPLv3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    4.0.81
+ * @version    4.0.9
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2023 SlickRemix
  *
@@ -27,7 +27,7 @@
  */
 
 // Set Plugin's Current Version.
-define( 'FTS_CURRENT_VERSION', '4.0.81' );
+define( 'FTS_CURRENT_VERSION', '4.0.9' );
 
 // Require file for plugin loading.
 require_once __DIR__ . '/class-load-plugin.php';

--- a/readme.txt
+++ b/readme.txt
@@ -118,7 +118,9 @@ Log into WordPress dashboard then click **Plugins** > **Add new** > Then under t
 16. Add the shortcode you generated from the settings page to any post, page, or text widget.
 
 == Changelog ==
-= Version 4.0.9 Tuesday, March 28th, 2023 =
+= Version 4.0.9 Wednesday, March 29th, 2023 =
+  * FIX: Facebook Feed. WordPress 6.2 conflict. PSR-0 depreciated, must use PSR-4 now.
+  * FIX: Instagram Basic Feed. Expiration refresh time increased from 7 days to 55 days.
   * UPDATED: readme.txt to credit WebFX.com for reporting security vulnerability.
 
 = Version 4.0.81 Tuesday, March 28th, 2023 =

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: Facebook, Instagram, Twitter, YouTube, Feed, Social Media, social, Instagr
 Requires at least: 5.4
 Requires PHP: 7.0
 Tested up to: 6.2
-Stable tag: 4.0.81
+Stable tag: 4.0.9
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -118,13 +118,16 @@ Log into WordPress dashboard then click **Plugins** > **Add new** > Then under t
 16. Add the shortcode you generated from the settings page to any post, page, or text widget.
 
 == Changelog ==
+= Version 4.0.9 Tuesday, March 28th, 2023 =
+  * UPDATED: readme.txt to credit WebFX.com for reporting security vulnerability.
+
 = Version 4.0.81 Tuesday, March 28th, 2023 =
   * FIX: Instagram Business: Access Token Inputs not displaying correctly.
   * UPDATED: POT file.
 
 = Version 4.0.8 Monday, March 27th, 2023 =
   * NEW: Feed Them Social Gutenberg Block support added.
-  * FIX: Security fixes.
+  * FIX: Security fixes. (Thanks WebFX.com for reporting the security vulnerability.)
   * UPDATED: Text strings for internationalization shortened and cleaned up.
   * FIX: Combined Streams: Facebook & Instagram Business Access Token clash.
 


### PR DESCRIPTION
= Version 4.0.9 Wednesday, March 29th, 2023 =
  * FIX: Facebook Feed. WordPress 6.2 conflict. PSR-0 depreciated, must use PSR-4 now.
  * FIX: Instagram Basic Feed. Expiration refresh time increased from 7 days to 55 days.
  * UPDATED: readme.txt to credit WebFX.com for reporting security vulnerability.