### PR TITLE
PSR-0 to PSR-4, Increase Insta Basic refresh token time to 55 days

### DIFF
--- a/feed-them-social.php
+++ b/feed-them-social.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social - Page, Post, Video and Photo Galleries
  * Plugin URI: https://feedthemsocial.com/
  * Description: Custom feeds for Instagram, Facebook Pages, Album Photos, Videos & Covers, Twitter & YouTube on pages, posts or widgets.
- * Version: 4.0.9
+ * Version: 4.1.0
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /includes/languages
  * Requires at least: WordPress 5.4
  * Tested up to: WordPress 6.2
- * Stable tag: 4.0.9
+ * Stable tag: 4.1.0
  * License: GPLv3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    4.0.9
+ * @version    4.1.0
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2023 SlickRemix
  *
@@ -27,7 +27,7 @@
  */
 
 // Set Plugin's Current Version.
-define( 'FTS_CURRENT_VERSION', '4.0.9' );
+define( 'FTS_CURRENT_VERSION', '4.1.0' );
 
 // Require file for plugin loading.
 require_once __DIR__ . '/class-load-plugin.php';

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: Facebook, Instagram, Twitter, YouTube, Feed, Social Media, social, Instagr
 Requires at least: 5.4
 Requires PHP: 7.0
 Tested up to: 6.2
-Stable tag: 4.0.9
+Stable tag: 4.1.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -118,7 +118,7 @@ Log into WordPress dashboard then click **Plugins** > **Add new** > Then under t
 16. Add the shortcode you generated from the settings page to any post, page, or text widget.
 
 == Changelog ==
-= Version 4.0.9 Wednesday, March 29th, 2023 =
+= Version 4.1.0 Wednesday, March 29th, 2023 =
   * FIX: Facebook Feed. WordPress 6.2 conflict. PSR-0 depreciated, must use PSR-4 now.
   * FIX: Instagram Basic Feed. Expiration refresh time increased from 7 days to 55 days.
   * UPDATED: readme.txt to credit WebFX.com for reporting security vulnerability.


### PR DESCRIPTION
= Version 4.1.0 Wednesday, March 29th, 2023 =
  * FIX: Facebook Feed. WordPress 6.2 conflict. PSR-0 depreciated, must use PSR-4 now.
  * FIX: Instagram Basic Feed. Expiration refresh time increased from 7 days to 55 days.
  * UPDATED: readme.txt to credit WebFX.com for reporting security vulnerability.