### PR TITLE
Instagram Loadmore fix, misslabeled youtube js function

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+= Version 3.0.2 Sunday, Nov 13th, 2022 =
+ * NOTE: Tested with WordPress Version 6.1
+ * COMING SOON: We are almost done with major version release 4.0. This will include a complete overhaul of the framework and interface to simplify the Feed Them Social experience.
+   Version 4.0 release will require all paid extensions to be updated to work with the new framework of the free plugin.
+
 = Version 3.0.1 Wednesday, July 20th, 2022 =
  * FIX: Facebook Options Page: notice if $test_fb_app_token_response->error was empty.
  * FIX: XSS Vulnerability: fts_fb_page_token_func, fts_instagram_token_ajax, feed_them_instagram_save_token

--- a/feed-them-social.php
+++ b/feed-them-social.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social - Page, Post, Video and Photo Galleries
  * Plugin URI: https://feedthemsocial.com/
  * Description: Custom feeds for Instagram, Facebook Pages, Album Photos, Videos & Covers, Twitter & YouTube on pages, posts or widgets.
- * Version: 4.1.3
+ * Version: 4.1.4
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 5.4
- * Tested up to: WordPress 6.2
- * Stable tag: 4.1.3
+ * Tested up to: WordPress 6.2.2
+ * Stable tag: 4.1.4
  * License: GPLv3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    4.1.3
+ * @version    4.1.4
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2023 SlickRemix
  *
@@ -27,7 +27,7 @@
  */
 
 // Set Plugin's Current Version.
-define( 'FTS_CURRENT_VERSION', '4.1.3' );
+define( 'FTS_CURRENT_VERSION', '4.1.4' );
 
 // Require file for plugin loading.
 require_once __DIR__ . '/class-load-plugin.php';

--- a/includes/feeds/instagram/class-instagram-feed.php
+++ b/includes/feeds/instagram/class-instagram-feed.php
@@ -1060,8 +1060,13 @@ if ( isset( $saved_feed_options['instagram_profile_description'], $saved_feed_op
                                             }
                                             jQuery('#loadMore_<?php echo esc_js( $fts_dynamic_name ); ?>').html('<?php echo esc_js( $instagram_load_more_text ); ?>');
                                             jQuery("#loadMore_<?php echo esc_js( $fts_dynamic_name ); ?>").removeClass('fts-fb-spinner');
-                                            jQuery.fn.ftsShare(); // Reload the share each funcion otherwise you can't open share option
-                                            jQuery.fn.slickInstagramPopUpFunction(); // Reload this function again otherwise the popup won't work correctly for the newly loaded items
+
+											if ( jQuery.isFunction(jQuery.fn.ftsShare) ) {
+												jQuery.fn.ftsShare(); // Reload the share each function otherwise you can't open share option
+											}
+											if( jQuery.isFunction(jQuery.fn.slickInstagramPopUpFunction) ){
+												jQuery.fn.slickInstagramPopUpFunction(); // Reload this function again otherwise the popup won't work correctly for the newly loaded items
+											}
                                             if (typeof outputSRmargin === "function") {
                                                 outputSRmargin(document.querySelector('#margin').value)
                                             } // Reload our margin for the demo

--- a/includes/feeds/js/fts-global-full.js
+++ b/includes/feeds/js/fts-global-full.js
@@ -332,7 +332,7 @@ function slickremixImageResizingYouTube() {
         ftsYoutubeThumbsContainer.css({
             'padding': ftsInstagramMargin
         });
-        var ftsImageHeightYouTube = ftsYoutubeImageSize.width() - '150';
+        var ftsImageHeightYoutube = ftsYoutubeImageSize.width() - '150';
         ftsYoutubeImageSize.css({
             'width': og_size,
             'height': ftsImageHeightYoutube,

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: https://www.slickremix.com/
 Tags: Facebook, Instagram, Twitter, YouTube, Feed, Social Media, social, Instagram photo, Instagram gallery, seo, gallery
 Requires at least: 5.4
 Requires PHP: 7.0
-Tested up to: 6.2
-Stable tag: 4.1.3
+Tested up to: 6.2.2
+Stable tag: 4.1.4
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -118,6 +118,10 @@ Log into WordPress dashboard then click **Plugins** > **Add new** > Then under t
 16. Add the shortcode you generated from the settings page to any post, page, or text widget.
 
 == Changelog ==
+= Version 4.1.4 Tuesday, May 23rd, 2023 =
+  * NOTE: Tested with WordPress version 6.2.2.
+  * FIX: Instagram Feed: Load more button was not working unless you had the option popup set to yes.
+
 = Version 4.1.3 Monday, May 8th, 2023 =
   * FIX: Translations were broken from wrong Domain Path set in main file.
   * FIX: Text strings had the wrong Text Domain set. The strings with feed_them_social are now updated to feed-them-social.
@@ -192,11 +196,6 @@ Log into WordPress dashboard then click **Plugins** > **Add new** > Then under t
   * 4.0.2 FIX: Re-added missing language files causing is_readable error for some users.
   * 4.0.2 UPDATED: Readme and PHP Required notation.
   * 4.0.2 FIX: Fix Permissions and remove it effecting global capabilities.
-
-= Version 3.0.2 Sunday, Nov 13th, 2022 =
-* NOTE: Tested with WordPress Version 6.1
-* COMING SOON: We are almost done with major version release 4.0. This will include a complete overhaul of the framework and interface to simplify the Feed Them Social experience.
-Version 4.0 release will require all paid extensions to be updated to work with the new framework of the free plugin.
 
 See Changelog.txt in the plugin for the full changelog.
 


### PR DESCRIPTION
= Version 4.1.4 Tuesday, May 23rd, 2023 =
  * NOTE: Tested with WordPress version 6.2.2.
  * FIX: Instagram Feed: Load more button was not working unless you had the option popup set to yes.