### PR TITLE
4.1.5

### DIFF
--- a/activate-plugin.php
+++ b/activate-plugin.php
@@ -121,7 +121,8 @@ class Activate_Plugin {
 	 */
 	public function load_translations_languages() {
 		// Localization. (Plugin string translations).
-		load_plugin_textdomain( 'feed-them-social', false, FEED_THEM_SOCIAL_PLUGIN_BASENAME . '/languages' );
+		// Needs FEED_THEM_SOCIAL_PLUGIN_FOLDER_DIR to make sure the path to languages folder is correct.
+		load_plugin_textdomain( 'feed-them-social', false, FEED_THEM_SOCIAL_PLUGIN_FOLDER_DIR . '/languages' );
 	}
 
 	/**

--- a/feed-them-social.php
+++ b/feed-them-social.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social - Page, Post, Video and Photo Galleries
  * Plugin URI: https://feedthemsocial.com/
  * Description: Custom feeds for Instagram, Facebook Pages, Album Photos, Videos & Covers, Twitter & YouTube on pages, posts or widgets.
- * Version: 4.1.4
+ * Version: 4.1.5
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 5.4
  * Tested up to: WordPress 6.2.2
- * Stable tag: 4.1.4
+ * Stable tag: 4.1.5
  * License: GPLv3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    4.1.4
+ * @version    4.1.5
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2023 SlickRemix
  *
@@ -27,7 +27,7 @@
  */
 
 // Set Plugin's Current Version.
-define( 'FTS_CURRENT_VERSION', '4.1.4' );
+define( 'FTS_CURRENT_VERSION', '4.1.5' );
 
 // Require file for plugin loading.
 require_once __DIR__ . '/class-load-plugin.php';

--- a/readme.txt
+++ b/readme.txt
@@ -119,7 +119,7 @@ Log into WordPress dashboard then click **Plugins** > **Add new** > Then under t
 
 == Changelog ==
 = Version 4.1.5 Wednesday, May 31st, 2023 =
-  * FIX: Path to languages folder was not correct. Thank you so much [@eriamel](https://wordpress.org/support/users/eriamel/) for pointing this out.
+  * FIX: The path to the languages folder was not correct. Thank you so much [@eriamel](https://wordpress.org/support/users/eriamel/) for pointing this out.
 
 = Version 4.1.4 Tuesday, May 23rd, 2023 =
   * NOTE: Tested with WordPress version 6.2.2.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: Facebook, Instagram, Twitter, YouTube, Feed, Social Media, social, Instagr
 Requires at least: 5.4
 Requires PHP: 7.0
 Tested up to: 6.2.2
-Stable tag: 4.1.4
+Stable tag: 4.1.5
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -118,6 +118,9 @@ Log into WordPress dashboard then click **Plugins** > **Add new** > Then under t
 16. Add the shortcode you generated from the settings page to any post, page, or text widget.
 
 == Changelog ==
+= Version 4.1.5 Wednesday, May 31st, 2023 =
+  * FIX: Path to languages folder was not correct. Thank you so much [@eriamel](https://wordpress.org/support/users/eriamel/) for pointing this out.
+
 = Version 4.1.4 Tuesday, May 23rd, 2023 =
   * NOTE: Tested with WordPress version 6.2.2.
   * FIX: Instagram Feed: Load more button was not working unless you had the option popup set to yes.


### PR DESCRIPTION
= Version 4.1.5 Wednesday, May 31st, 2023 =
  * FIX: The path to the languages folder was not correct. Thank you so much [@eriamel](https://wordpress.org/support/users/eriamel/) for pointing this out.