### PR TITLE
4.1.7.1

### DIFF
--- a/admin/cpt/options/cpt-settings-options-js.php
+++ b/admin/cpt/options/cpt-settings-options-js.php
@@ -252,9 +252,11 @@ class Settings_Options_JS {
                     <?php } ?>
 
                     // only show the post type visible if the facebook page feed type is selected
-                    jQuery('.facebook-post-type-visible').hide();
+                    // jQuery('.facebook-post-type-visible').hide();
                     if (facebooktype == 'page') {
-                        jQuery('.facebook-post-type-visible').show();
+                        // SRL 8-23-23: We need to hide this option now because it requires the
+                        // pages_read_user_content or Page Public Content Access permission.
+                        jQuery('.facebook-post-type-visible').hide();
                     }
                     var fb_feed_type_option = jQuery("select#facebook_page_feed_type").val();
                     if (fb_feed_type_option == 'album_photos') {

--- a/admin/cpt/options/feeds-cpt-options.php
+++ b/admin/cpt/options/feeds-cpt-options.php
@@ -1493,7 +1493,12 @@ class Feed_CPT_Options {
 						),
 						array(
 							'label' => __( 'Display Posts made by Page and Others', 'feed-them-social' ),
-							'value' => 'page_and_others',
+							'value' => 'page_only',
+							// SRL 8-23-23: We need to remove this option now because it requires the
+							// pages_read_user_content or Page Public Content Access permission.
+							// I made it default to page_only in case current users had the option selected.
+							// This way if they save the page again it will convert to page_only.
+							//'value' => 'page_and_others',
 						),
 					),
 					'short_attr'       => array(

--- a/includes/feeds/facebook/class-facebook-feed.php
+++ b/includes/feeds/facebook/class-facebook-feed.php
@@ -1366,13 +1366,18 @@ style="margin:' . ( isset( $saved_feed_options['slider_margin'] ) && '' !== $sav
                     return 'Please Purchase and Activate the Feed Them Social Reviews plugin.';
                 }
             } else {
+                // This is meant for posts made by others option, however it now requires a new permission from Facebook that we do not have. Page Public Content Access.
                 $mulit_data = array( 'page_data' => 'https://graph.facebook.com/' . $saved_feed_options['fts_facebook_custom_api_token_user_id'] . '?fields=feed,id,name,description&access_token=' . $this->feed_access_token . $language . '' );
 
-                // Check If Ajax next URL needs to be used.
+                if ( isset( $_REQUEST['next_url'] ) ) {
+                    $_REQUEST['next_url'] = str_replace( 'access_token=XXX', 'access_token=' . $this->feed_access_token, $_REQUEST['next_url'] );
+                }
+
                 if ( ! $fts_count_ids >= 1 ) {
-                    $mulit_data['feed_data'] = $_REQUEST['next_url'] ? esc_url_raw( $_REQUEST['next_url'] ) : esc_url_raw( 'https://graph.facebook.com/' . $saved_feed_options['fts_facebook_custom_api_token_user_id'] . '/feed?fields=id,created_time,from,icon,message,name_id,picture,full_picture,place,shares,status_type,story,to&limit=' . $saved_feed_options['facebook_page_post_count'] . '&access_token=' . $this->feed_access_token . $language . '' );
+                    // We cannot add sanitize_text_field here on the $_REQUEST['next_url'] otherwise it will fail to load the contents from the facebook API.
+                    $mulit_data['feed_data'] = !empty( $_REQUEST['next_url'] ) ? esc_url_raw( $_REQUEST['next_url'] ) : esc_url_raw( 'https://graph.facebook.com/' . $saved_feed_options['fts_facebook_custom_api_token_user_id'] . '/posts?fields=id,attachments,created_time,from,icon,message,picture,full_picture,place,shares,status_type,story,to&limit=' . $saved_feed_options['facebook_page_post_count'] . '&access_token=' . $this->feed_access_token . $language . '' );
                 } else {
-                    $mulit_data['feed_data'] = $_REQUEST['next_url'] ? esc_url_raw( $_REQUEST['next_url'] ) : esc_url_raw( 'https://graph.facebook.com/feed?ids=' . $saved_feed_options['fts_facebook_custom_api_token_user_id'] . '&fields=id,created_time,from,icon,message,name_id,picture,full_picture,place,shares,status_type,story,to&limit=' . $saved_feed_options['facebook_page_post_count'] . '&access_token=' . $this->feed_access_token . $language . '' );
+                    $mulit_data['feed_data'] = !empty( $_REQUEST['next_url'] ) ? esc_url_raw( $_REQUEST['next_url'] ) : esc_url_raw( 'https://graph.facebook.com/posts?ids=' . $saved_feed_options['fts_facebook_custom_api_token_user_id'] . '&fields=id,attachments,created_time,from,icon,message,picture,full_picture,place,shares,status_type,story,to&limit=' . $saved_feed_options['facebook_page_post_count'] . '&access_token=' . $this->feed_access_token . $language . '' );
                 }
             }
             $response = $this->feed_functions->fts_get_feed_json( $mulit_data );

--- a/readme.txt
+++ b/readme.txt
@@ -122,7 +122,8 @@ Log into WordPress dashboard then click **Plugins** > **Add new** > Then under t
   * FIX: Security fix. User controlled data able to be entered into Leave a Review message. (Thanks to the researcher Abdi Pranata at Patchstack.com for reporting the security vulnerability.)
   * FIX: Sanitize text fields on Twitter urls.
   * FIX: Facebook Feed: Share and View on Facebook link not displaying for posts with no image or video.
-  * FIX: Facebook Feed: Likes and Comments and the option "Display Posts made by Page and Others" were not working correctly because a new permission was introduced in the API that was required. Get a new access token and these features will work again.
+  * FIX: Facebook Feed: Likes and Comments were not working correctly because a new permission was introduced in the API that was required. Get a new access token and these features will work again.
+  * REMOVE: Facebook Feed: Remove the option "Display Posts made by Page and Others" now because one, you cannot post to a page anymore you can only tag a page and two this now requires the Page Public Content Access permission which we do not have currently. We will inquire to see if we can get this permission for our plugin.
 
 = Version 4.1.6 Thursday, June 6th, 2023 =
   * NEW: Beaver Builder Module added. When editing or creating a new page, or post you can look for Social Modules and Feed Them Social will appear. You can also search for social in the modules list and Feed Them Social will appear.


### PR DESCRIPTION
= Version 4.1.7 Thursday, August 24th, 2023 =
  * FIX: Security fix. User controlled data able to be entered into Leave a Review message. (Thanks to the researcher Abdi Pranata at Patchstack.com for reporting the security vulnerability.)
  * FIX: Sanitize text fields on Twitter urls.
  * FIX: Facebook Feed: Share and View on Facebook link not displaying for posts with no image or video.
  * FIX: Facebook Feed: Likes and Comments were not working correctly because a new permission was introduced in the API that was required. Get a new access token and these features will work again.
  * REMOVE: Facebook Feed: Remove the option "Display Posts made by Page and Others" now because one, you cannot post to a page anymore you can only tag a page and two this now requires the Page Public Content Access permission which we do not have currently. We will inquire to see if we can get this permission for our plugin.