### PR TITLE
4.1.8

### DIFF
--- a/feed-them-social.php
+++ b/feed-them-social.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social - Page, Post, Video and Photo Galleries
  * Plugin URI: https://feedthemsocial.com/
  * Description: Custom feeds for Instagram, Facebook Pages, Album Photos, Videos & Covers, Twitter & YouTube on pages, posts or widgets.
- * Version: 4.1.7
+ * Version: 4.1.8
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 5.4
- * Tested up to: WordPress 6.3
- * Stable tag: 4.1.7
+ * Tested up to: WordPress 6.3.1
+ * Stable tag: 4.1.8
  * License: GPLv3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    4.1.7
+ * @version    4.1.8
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2023 SlickRemix
  *
@@ -27,7 +27,7 @@
  */
 
 // Set Plugin's Current Version.
-define( 'FTS_CURRENT_VERSION', '4.1.7' );
+define( 'FTS_CURRENT_VERSION', '4.1.8' );
 
 // Require file for plugin loading.
 require_once __DIR__ . '/class-load-plugin.php';

--- a/includes/feeds/facebook/class-facebook-feed-post-types.php
+++ b/includes/feeds/facebook/class-facebook-feed-post-types.php
@@ -623,9 +623,7 @@ class Facebook_Feed_Post_Types {
 					}
 				}
                 else {
-                    $fb_username = !empty( $facebook_post_username ) ? $facebook_post_username : $fb_post_user_id ;
-                    $username_without_spaces = str_replace(' ', '', $fb_username);
-                    $post_single_id = 'https://www.facebook.com/' . $username_without_spaces . '/posts/' . $fb_post_single_id;
+                    $post_single_id = 'https://www.facebook.com/' . $fb_post_user_id . '_' . $fb_post_id;
                     echo '<div class="fts-likes-shares-etc-wrap">';
                     echo $this->feed_functions->fts_share_option( $post_single_id, $description );
                     echo '<a href="' . esc_url( $post_single_id ) . '" target="_blank" rel="noreferrer" class="fts-jal-fb-see-more">';

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: https://www.slickremix.com/
 Tags: Facebook, Instagram, Twitter, YouTube, Feed, Social Media, social, Instagram photo, Instagram gallery, seo, gallery
 Requires at least: 5.4
 Requires PHP: 7.0
-Tested up to: 6.3
-Stable tag: 4.1.7
+Tested up to: 6.3.1
+Stable tag: 4.1.8
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -118,6 +118,10 @@ Log into WordPress dashboard then click **Plugins** > **Add new** > Then under t
 16. Add the shortcode you generated from the settings page to any post, page, or text widget.
 
 == Changelog ==
+= Version 4.1.8 Monday, September 2nd, 2023 =
+  * FIX: Facebook Feed: Facebook link not directing properly for page names that don't match the url of the page.
+  * NOTE: Works with WordPress version 6.3.1.
+
 = Version 4.1.7 Monday, August 28th, 2023 =
   * FIX: Security fix. User controlled data was able to be entered into the Leave a Review message container. (Thanks to the researcher Abdi Pranata at Patchstack.com for reporting the security vulnerability.)
   * FIX: Sanitize text fields on Twitter urls.

--- a/readme.txt
+++ b/readme.txt
@@ -118,8 +118,8 @@ Log into WordPress dashboard then click **Plugins** > **Add new** > Then under t
 16. Add the shortcode you generated from the settings page to any post, page, or text widget.
 
 == Changelog ==
-= Version 4.1.8 Monday, September 2nd, 2023 =
-  * FIX: Facebook Feed: Facebook link not directing properly for page names that don't match the url of the page.
+= Version 4.1.8 Saturday, September 2nd, 2023 =
+  * FIX: Facebook Feed: Link for posts with only text were not directing to Facebook properly.
   * NOTE: Works with WordPress version 6.3.1.
 
 = Version 4.1.7 Monday, August 28th, 2023 =


### PR DESCRIPTION
= Version 4.1.8 Saturday, September 2nd, 2023 =
  * FIX: Facebook Feed: Link for posts with only text were not directing to Facebook properly.
  * NOTE: Works with WordPress version 6.3.1.