### PR TITLE
4.2.5

### DIFF
--- a/feed-them-social.php
+++ b/feed-them-social.php
@@ -7,7 +7,7 @@
  * Plugin Name: Feed Them Social - Page, Post, Video and Photo Galleries
  * Plugin URI: https://feedthemsocial.com/
  * Description: Custom feeds for Instagram, TikTok, Facebook Pages, Album Photos, Videos & Covers & YouTube on pages, posts, widgets, Elementor & Beaver Builder.
- * Version: 4.2.4
+ * Version: 4.2.5
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social


### PR DESCRIPTION
= Version 4.2.5 Monday, February 19th, 2024 =
  * Update: Facebook & Instagram Business: The business_management permission was added to the access token request. This will allow you to retrieve page(s) you are admin of that are located within your Facebook Business Manager.
  * NOTE: Works with WordPress version 6.4.3