### PR TITLE
4.2.7

### DIFF
--- a/feed-them-social.php
+++ b/feed-them-social.php
@@ -7,18 +7,18 @@
  * Plugin Name: Feed Them Social - Page, Post, Video and Photo Galleries
  * Plugin URI: https://feedthemsocial.com/
  * Description: Custom feeds for Instagram, TikTok, Facebook Pages, Album Photos, Videos & Covers & YouTube on pages, posts, widgets, Elementor & Beaver Builder.
- * Version: 4.2.6
+ * Version: 4.2.7
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 5.4
- * Tested up to: WordPress 6.4.3
- * Stable tag: 4.2.6
+ * Tested up to: WordPress 6.5.2
+ * Stable tag: 4.2.7
  * License: GPLv3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    4.2.6
+ * @version    4.2.7
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2024 SlickRemix
  *
@@ -27,7 +27,7 @@
  */
 
 // Set Plugin's Current Version.
-define( 'FTS_CURRENT_VERSION', '4.2.6' );
+define( 'FTS_CURRENT_VERSION', '4.2.7' );
 
 // Require file for plugin loading.
 require_once __DIR__ . '/class-load-plugin.php';


### PR DESCRIPTION
= Version 4.2.7 Thursday, April 11th, 2024 =
  * Update: Feed Them Social works with WordPress version 6.5.2