### PR TITLE
4.3.3

### DIFF
--- a/admin/cpt/access-tokens/single/instagram-access-token.php
+++ b/admin/cpt/access-tokens/single/instagram-access-token.php
@@ -153,7 +153,7 @@ class Instagram_Access_Functions {
 
         echo sprintf(
             esc_html__( '%1$sLogin and Get my Access Token%2$s', 'feed-them-social' ),
-            '<div class="fts-clear fts-token-spacer"></div><a href="' . esc_url( 'https://www.instagram.com/oauth/authorize?enable_fb_login=0&force_authentication=1&client_id=523345500405663&redirect_uri=https://www.slickremix.com/instagram-business-basic-token-redirect/&response_type=code&scope=instagram_business_basic&state=' . urlencode( urlencode( urlencode( $post_url ) ) ) ) . '" class="fts-instagram-get-access-token">',
+            '<div class="fts-clear fts-token-spacer"></div><a href="' . esc_url( 'https://api.instagram.com/oauth/authorize?client_id=523345500405663&redirect_uri=https://www.slickremix.com/instagram-business-basic-token-redirect/&response_type=code&scope=instagram_business_basic&state=' . urlencode( urlencode( urlencode( $post_url ) ) ) ) . '" class="fts-instagram-get-access-token">',
             '</a>'
 
            /* esc_html__( '%1$sLogin and Get my Access Token%2$s', 'feed-them-social' ),

--- a/feed-them-social.php
+++ b/feed-them-social.php
@@ -7,20 +7,20 @@
  * Plugin Name: Feed Them Social - Social Media Feeds, Video, and Photo Galleries
  * Plugin URI: https://feedthemsocial.com/
  * Description: Custom feeds for Instagram, TikTok, Facebook Pages, Album Photos, Videos & Covers & YouTube on pages, posts, widgets, Elementor & Beaver Builder.
- * Version: 4.3.2
+ * Version: 4.3.3
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 5.4
  * Tested up to: WordPress 6.6.2
- * Stable tag: 4.3.2
+ * Stable tag: 4.3.3
  * Requires PHP: 7.0
  * Tested PHP: 8.3
  * License: GPLv3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    4.3.2
+ * @version    4.3.3
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2024 SlickRemix
  *
@@ -29,7 +29,7 @@
  */
 
 // Set Plugin's Current Version.
-define( 'FTS_CURRENT_VERSION', '4.3.2' );
+define( 'FTS_CURRENT_VERSION', '4.3.3' );
 
 // Require file for plugin loading.
 require_once __DIR__ . '/class-load-plugin.php';

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: https://www.slickremix.com/
 Tags: Instagram, Facebook, TikTok, YouTube, Social
 Requires at least: 5.4
 Requires PHP: 7.0
-Tested up to: 6.6.2
-Stable tag: 4.3.2
+Tested up to: 6.6.7
+Stable tag: 4.3.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -124,8 +124,12 @@ Log into WordPress dashboard then click **Plugins** > **Add new** > Then under t
 16. Add the shortcode you generated from the settings page to any post, page, or text widget.
 
 == Changelog ==
+= Version 4.3.3 Monday, November 18th, 2024 =
+  * Fix: Instagram Feed > Get Access Token > Instagram was returning, Error Please wait a few minutes before you try again, for many users. I found using 5G helped but that does not help everyone. Restructured the url to prevent this error.
+  * NOTE: Works with WordPress version 6.4.7
+
 = Version 4.3.2 Wednesday, October 30th, 2024 =
-  * Update: Instagram Feed Basic > [You must get a new access token](https://www.slickremix.com/documentation/connect-instagram-professional-account/) before December 4th. Depreciation Notice on December 4th, 2024 for the Instagram Basic API. The new connection requires your Instagram account to be a Professional with the Creator or Business option set. We have updated the plugin to reflect this change. Login to your Instagram Account and go to your Profile page, then click the gear icon and choose the Settings, then scroll down and find the Creator Tools and Controls menu option. Now choose either a Business or Creator option. Then you can click the button on our plugin to gain an Access Token. Your account cannot be set to personal for this to work. [More Indepth Info](https://developers.facebook.com/blog/post/2024/09/04/update-on-instagram-basic-display-api/)
+  * Update: Instagram Feed Basic > [You must get a new access token](https://www.slickremix.com/documentation/connect-instagram-professional-account/) before December 4th. Depreciation Notice on December 4th, 2024 for the Instagram Basic API. The new connection requires your Instagram account to be a Professional with the Creator or Business option set. We have updated the plugin to reflect this change. Login to your Instagram Account and go to your Profile page, then click the gear icon and choose the Settings, then scroll down and find the Creator Tools and Controls menu option. Now choose either a Business or Creator option. Then you can click the button on our plugin to gain an Access Token. Your account cannot be set to personal for this to work. [More In-depth Info](https://developers.facebook.com/blog/post/2024/09/04/update-on-instagram-basic-display-api/)
   * New: Instagram Feed > The profile photo now displays for the updated Instagram Feed.
   * New: Instagram Basic Business Feed > Cron Job > Access Token will automatically refresh every 54 days.
   * New: YouTube Feed > Cron Job > Access Token will automatically refresh every hour. We still recommend using an [API Key](https://www.slickremix.com/documentation/create-youtube-api-key/).


### PR DESCRIPTION
= Version 4.3.3 Monday, November 18th, 2024 =
  * Fix: Instagram Feed > Get Access Token > Instagram was returning, Error Please wait a few minutes before you try again, for many users. I found using 5G helped but that does not help everyone. Restructured the URL to prevent this error.
  * NOTE: Works with WordPress version 6.4.7