### PR TITLE
4.3.7

### DIFF
--- a/feed-them-social.php
+++ b/feed-them-social.php
@@ -7,20 +7,20 @@
  * Plugin Name: Feed Them Social - Social Media Feeds, Video, and Photo Galleries
  * Plugin URI: https://feedthemsocial.com/
  * Description: Custom feeds for Instagram, TikTok, Facebook Pages, Album Photos, Videos & Covers & YouTube on pages, posts, widgets, Elementor & Beaver Builder.
- * Version: 4.3.6
+ * Version: 4.3.7
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-social
  * Domain Path: /languages
  * Requires at least: WordPress 5.4
- * Tested up to: WordPress 6.7.2
- * Stable tag: 4.3.6
+ * Tested up to: WordPress 6.8
+ * Stable tag: 4.3.7
  * Requires PHP: 7.0
  * Tested PHP: 8.3
  * License: GPLv3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    4.3.6
+ * @version    4.3.7
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2025 SlickRemix
  *
@@ -29,7 +29,7 @@
  */
 
 // Set Plugin's Current Version.
-define( 'FTS_CURRENT_VERSION', '4.3.6' );
+define( 'FTS_CURRENT_VERSION', '4.3.7' );
 
 // Require file for plugin loading.
 require_once __DIR__ . '/class-load-plugin.php';

--- a/includes/feeds/youtube/class-youtube-feed.php
+++ b/includes/feeds/youtube/class-youtube-feed.php
@@ -364,7 +364,7 @@ class Youtube_Feed {
 
                 elseif ( $saved_feed_options['youtube_feed_type'] === 'playlistID' && ! empty( $saved_feed_options['youtube_playlistID'] )  ) {
 
-                    // I don't understand the section here.. blllaaaaaahh need to clean this mess up!
+                    // I don't understand the section here.. Need to clean this up.
                    // echo '<br/>playlistID shortcode in use: ';
 
                     $youtube_feed_api_url = isset( $_REQUEST['next_url'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['next_url'] ) ) : sanitize_text_field( wp_unslash( 'https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&maxResults=' . $vid_count . '&playlistId=' . $saved_feed_options['youtube_playlistID'] . '&order=date&' . $youtube_api_key_or_token ) );
@@ -1129,13 +1129,13 @@ class Youtube_Feed {
 	 * @since 1.9.6
 	 */
 	public function fts_youtube_video_and_wrap( $post_data, $feed_type ) {
-		$ssl                                = is_ssl() ? 'https' : 'http';
+		$ssl = is_ssl() ? 'https' : 'http';
 
         /*echo '<pre>';
         echo print_r($post_data);
         echo '</pre>';*/
 
-		if ( 'username' === $feed_type || 'userPlaylist' === $feed_type || 'playlistID' === $feed_type ) {
+		if ( $feed_type === 'username' || $feed_type === 'userPlaylist' || $feed_type === 'playlistID' ) {
             $youtube_video_user_or_playlist_url = !empty( $post_data->snippet->resourceId->videoId ) ? $post_data->snippet->resourceId->videoId : '';
 			$youtube_video_iframe = '<div class="fts-fluid-videoWrapper"><iframe src="' . esc_url( $ssl . '://www.youtube.com/embed/' . $youtube_video_user_or_playlist_url ) . '?wmode=transparent&HD=0&rel=0&showinfo=0&controls=1&autoplay=0" frameborder="0" allowfullscreen></iframe></div>';
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: https://www.slickremix.com/
 Tags: Instagram, Facebook, TikTok, YouTube, Social
 Requires at least: 5.4
 Requires PHP: 7.0
-Tested up to: 6.7.2
-Stable tag: 4.3.6
+Tested up to: 6.8
+Stable tag: 4.3.7
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -124,6 +124,12 @@ Log into WordPress dashboard then click **Plugins** > **Add new** > Then under t
 16. Add the shortcode you generated from the settings page to any post, page, or text widget.
 
 == Changelog ==
+= Version 4.3.7 Tuesday, April 15th, 2025 =
+  * Works with WordPress version 6.8
+  * Note > Combined Streams Extension > Fix: YouTube Feed > feed_type added to fts_youtube_video_and_wrap function because only Channel ID Videos were showing up. This was causing videos to not appear if you were using a Playlist ID.
+  * Note > Combined Streams Extension > Fix: replace get_plugin_data() function with a constant FTS_PREMIUM_CURRENT_VERSION to get the plugin version. Fixes the Doing It Wrong warning.
+  * Note > Combined Streams Extension > Fix: re-order yoda arguments.
+
 = Version 4.3.6 Wednesday, March 12th, 2025 =
   * Fix: Instagram Feed > escape_attributes function was outputting links with double quotes around the attributes.
   * New: System Info > Additional Licence Key info added.


### PR DESCRIPTION
= Version 4.3.7 Tuesday, April 15th, 2025 =
  * Works with WordPress version 6.8
  * Note > Combined Streams Extension > Fix: YouTube Feed > feed_type added to fts_youtube_video_and_wrap function because only Channel ID Videos were showing up. This was causing videos to not appear if you were using a Playlist ID.
  * Note > Combined Streams Extension > Fix: replace get_plugin_data() function with a constant FTS_PREMIUM_CURRENT_VERSION to get the plugin version. Fixes the Doing It Wrong warning.
  * Note > Combined Streams Extension > Fix: re-order yoda arguments.