### PR TITLE
4.3.9

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,12 @@
+# Required SonarQube project properties
+sonar.projectKey=SlickRemix_feed-them-social
+sonar.projectName=feed-them-social
+
+# Path to the source code to be analyzed (the current directory)
+sonar.sources=.
+
+# Encoding of the source files
+sonar.sourceEncoding=UTF-8
+
+# EXCLUSION FOR MAGNIFIC POPUP ==
+sonar.exclusions=**/includes/feeds/js/magnific-popup.js


### PR DESCRIPTION
add sonar.project.properties to exclude magnific popup script from analyzing.