### PR TITLE
4.3.9

### DIFF
--- a/ActivatePlugin.php
+++ b/ActivatePlugin.php
@@ -553,11 +553,11 @@ class ActivatePlugin {
      * @since 4.3.9
      */
     public function checkAutoUpdatedPlugins( $update_results ) {
-        if ( ! empty( $results['plugin'] ) && is_array( $results['plugin'] ) ) {
+        if ( ! empty( $update_results['plugin'] ) && \is_array( $update_results['plugin'] ) ) {
             $error_handler = new ErrorHandler();
             $extensions = array_keys( $error_handler->ftsVersionsNeeded() );
 
-            foreach ( $results['plugin'] as $result ) {
+            foreach ( $update_results['plugin'] as $result ) {
                 if ( ! empty( $result->item->plugin ) && \in_array( $result->item->plugin, $extensions, true ) ) {
                     DebugLog::log( 'ActivatePlugin', 'FTS Extension auto-updated: ' . $result->item->plugin . '. Will run version check.', true );
                     // An extension was updated, run the check.

--- a/includes/ErrorHandler.php
+++ b/includes/ErrorHandler.php
@@ -111,7 +111,7 @@ class ErrorHandler {
 
                         // Custom message for Combined Streams plugin
                         if ( $single_plugin === 'feed-them-social-combined-streams/feed-them-social-combined-streams.php' ) {
-                            $combined_streams_msg = 'Your <strong>Feed Them Social Combined Streams</strong> plugin version is 2.0.5 or less and needs to be upgraded to version 2.0.6 or higher. Please update your extension from your <a href="https://www.slickremix.com/my-account/" target="_blank">My Account</a> page on our website.';
+                            $combined_streams_msg = 'Your <strong>Feed Them Social Combined Streams</strong> plugin version is 2.0.4 or less and needs to be upgraded to version 2.0.5 or higher. Please update your extension from your <a href="https://www.slickremix.com/my-account/" target="_blank">My Account</a> page on our website.';
                             throw new \Exception( '<div class="error notice"><p>' . $combined_streams_msg . '</p></div>' );
                         }
 

--- a/includes/ErrorHandler.php
+++ b/includes/ErrorHandler.php
@@ -104,20 +104,18 @@ class ErrorHandler {
 
             foreach ( $fts_versions_needed as $single_plugin => $plugin_info ) {
 
-                if ( isset( $plugins[ $single_plugin ] ) ) {
-                    // Check Version Compatibility if Extensions are not a new enough version deactivate them and throw errors!
-                    if ( $plugins[ $single_plugin ]['Version'] < $fts_versions_needed[ $single_plugin ]['version_needed'] && is_plugin_active( $single_plugin ) ) {
-                        deactivate_plugins( $single_plugin );
+                // Check Version Compatibility if Extensions are not a new enough version deactivate them and throw errors!
+                if ( isset( $plugins[$single_plugin] ) && $plugins[$single_plugin]['Version'] < $fts_versions_needed[$single_plugin]['version_needed'] && is_plugin_active( $single_plugin ) ) {
+                    deactivate_plugins( $single_plugin );
 
-                        // Custom message for Combined Streams plugin
-                        if ( $single_plugin === 'feed-them-social-combined-streams/feed-them-social-combined-streams.php' ) {
-                            $combined_streams_msg = 'Your <strong>Feed Them Social Combined Streams</strong> plugin version is 2.0.4 or less and needs to be upgraded to version 2.0.5 or higher. Please update your extension from your <a href="https://www.slickremix.com/my-account/" target="_blank">My Account</a> page on our website.';
-                            throw new \Exception( '<div class="error notice"><p>' . $combined_streams_msg . '</p></div>' );
-                        }
-
-                        // Don't Let Old Plugins Activate!
-                        throw new \Exception( '<div class="error notice"><p>' . $update_msg . '</p></div>' );
+                    // Custom message for Combined Streams plugin
+                    if ( $single_plugin === 'feed-them-social-combined-streams/feed-them-social-combined-streams.php' ) {
+                        $combined_streams_msg = 'Your <strong>Feed Them Social Combined Streams</strong> plugin version is 2.0.4 or less and needs to be upgraded to version 2.0.5 or higher. Please update your the extension from the plugins page or download the latest version from your <a href="https://www.slickremix.com/my-account/" target="_blank">My Account</a> page on our website.';
+                        throw new \Exception( '<div class="error notice"><p>' . $combined_streams_msg . '</p></div>' );
                     }
+
+                    // Don't Let Old Plugins Activate!
+                    throw new \Exception( '<div class="error notice"><p>' . $update_msg . '</p></div>' );
                 }
             }
         } catch ( \Exception $e ) {

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Feed Them Social - Social Media Feeds, Video, and Photo Galleries ===
 Contributors: slickremix
 Donate link: https://www.slickremix.com/
-Tags: Instagram, Facebook, TikTok, YouTube, Social
+Tags: instagram, facebook, tikTok, youtube, social
 Requires at least: 5.4
 Requires PHP: 7.0
 Tested up to: 6.8.2
@@ -9,7 +9,7 @@ Stable tag: 4.3.9
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
-Custom social media feeds for Instagram, Facebook Pages, Album Photos, Videos & Covers, TikTok, & YouTube on pages, posts, widgets, Elementor & Beaver Builder.
+Custom social media feeds for Instagram, Facebook, TikTok, & YouTube. Works with Elementor, Beaver Builder, and Gutenberg blocks.
 
 == Description ==
 Easily Create and Display Customizable Social Feeds from Instagram, Facebook, TikTok, or YouTube. Responsive on Desktops, Tablets, and Mobile Devices.

--- a/readme.txt
+++ b/readme.txt
@@ -125,8 +125,8 @@ Log into WordPress dashboard then click **Plugins** > **Add new** > Then under t
 
 == Changelog ==
 = Version 4.3.9 Monday, September 22nd, 2025 =
-  * Refactor files to use PSR-4 autoloading standard.
-  * Refactor Classes and File Names to use PascalCase and functions to be camelCase.
+  * Refactor: Use PSR-4 autoloading standard.
+  * Refactor: Classes and File Names to use PascalCase and functions to be camelCase.
   * Fix: Settings > General > When deleting cache the cache time option was reset on settings page.
   * Fix: System Info > Cron Job Cache time reported was incorrect.
   * Fix: License Updater > Update notifications and version update description not showing.

--- a/readme.txt
+++ b/readme.txt
@@ -16,8 +16,8 @@ Easily Create and Display Customizable Social Feeds from Instagram, Facebook, Ti
 
 ###Features
  * **Quick** Install and Set up.
- * **Create** as many social feeds as you want!
- * **Display** social feeds on any post, page, or sidebar!
+ * **Create** as many social feeds as you want.
+ * **Display** social feeds on any post, page, or sidebar.
  * **Responsive** Design for Social Feeds on all devices.
  * **Saved** Feed options for easy editing.
  * **View** your Feed while editing the options.
@@ -124,11 +124,12 @@ Log into WordPress dashboard then click **Plugins** > **Add new** > Then under t
 16. Add the shortcode you generated from the settings page to any post, page, or text widget.
 
 == Changelog ==
-= Version 4.3.9 Wednesday, September 9th, 2025 =
+= Version 4.3.9 Monday, September 22nd, 2025 =
   * Refactor files to use PSR-4 autoloading standard.
   * Refactor Classes and File Names to use PascalCase and functions to be camelCase.
   * Fix: Settings > General > When deleting cache the cache time option was reset on settings page.
   * Fix: System Info > Cron Job Cache time reported was incorrect.
+  * Fix: License Updater > Update notifications and version update description not showing.
   * Remove: Twitter Code.
   * Remove: Convert Legacy Shortcode option.
   * Works with WordPress version 6.8.2

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,4 +15,4 @@ sonar.exclusions=**/includes/feeds/js/magnific-popup.js
 # Exclude MD5 usage warnings for cache key generation (false positive)
 sonar.issue.ignore.multicriteria=e1
 sonar.issue.ignore.multicriteria.e1.ruleKey=php:S4790
-sonar.issue.ignore.multicriteria.e1.resourceKey=**/updater/UpdaterCheckClass.php
+sonar.issue.ignore.multicriteria.e1.resourceKey=updater/UpdaterCheckClass.php

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,3 +10,9 @@ sonar.sourceEncoding=UTF-8
 
 # EXCLUSION FOR MAGNIFIC POPUP ==
 sonar.exclusions=**/includes/feeds/js/magnific-popup.js
+
+# RULE EXCLUSIONS ==
+# Exclude MD5 usage warnings for cache key generation (false positive)
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=php:S4790
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/updater/UpdaterCheckClass.php

--- a/updater/UpdaterCheckClass.php
+++ b/updater/UpdaterCheckClass.php
@@ -232,6 +232,7 @@ class UpdaterCheckClass {
 
         // Check if the update cache needs to be populated.
         if ( empty( $update_cache->response[ $this->name ] ) ) {
+            // NOSONAR php:S4790 - MD5 used for cache key generation, not cryptographic security
             $cache_key    = md5( 'edd_plugin_' . sanitize_key( $this->name ) . '_version_info' );
             $version_info = get_transient( $cache_key );
 
@@ -305,6 +306,7 @@ class UpdaterCheckClass {
      */
     public function pluginsApiFilter($_data, $_action = '', $_args = null) {
 
+        // NOSONAR php:S4790 - MD5 used for cache key generation, not cryptographic security
         delete_site_transient('edd_api_request_' . substr(md5(serialize('feed-them-premium')), 0, 15));
 
         if ( $_action !== 'plugin_information' ) {
@@ -324,6 +326,7 @@ class UpdaterCheckClass {
             )
         );
 
+        // NOSONAR php:S4790 - MD5 used for cache key generation, not cryptographic security
         $cache_key = 'edd_api_request_' . substr(md5(serialize($this->slug)), 0, 15);
 
         //Get the transient where we store the api request for this plugin for 24 hours
@@ -536,6 +539,7 @@ class UpdaterCheckClass {
         }
 
         $data       = $edd_plugin_data[ $_REQUEST['slug'] ];
+        // NOSONAR php:S4790 - MD5 used for cache key generation, not cryptographic security
         $cache_key  = md5( 'edd_plugin_' . sanitize_key( $_REQUEST['plugin'] ) . '_version_info' );
         $version_info = get_transient( $cache_key );
 

--- a/updater/UpdaterCheckInit.php
+++ b/updater/UpdaterCheckInit.php
@@ -68,8 +68,6 @@ class UpdaterCheckInit {
      * UpdaterCheckInit constructor.
      */
     public function __construct( $feedFunctions ) {
-        // Debug logging - remove after testing
-        error_log("FTS UpdaterCheckInit: Constructor called");
         // New Updater! - This is the URL our updater / license checker pings. This should be the URL of the site with EDD installed!
         if ( ! \function_exists( 'is_plugin_active' ) ) {
             require_once ABSPATH . '/wp-admin/includes/plugin.php';
@@ -190,16 +188,11 @@ class UpdaterCheckInit {
     public function pluginUpdaterCheckInit() {
 
         $installed_plugins = get_plugins();
-        
-        // Debug logging - remove after testing
-        error_log("FTS pluginUpdaterCheckInit: Starting check for " . count($this->premExtensionList) . " premium extensions");
 
         // Simple Checks print_r($this->updaterOptionsInfo['store_url']) and also print_r($this->updaterOptionsInfo)
         foreach ( $this->premExtensionList as $plugin_identifier => $plugin_info) {
             
-            error_log("FTS pluginUpdaterCheckInit: Checking plugin " . $plugin_identifier . " with URL: " . ($plugin_info['plugin_url'] ?? 'NOT SET'));
             $is_active = isset($plugin_info['plugin_url']) && !empty($plugin_info['plugin_url']) && is_plugin_active($plugin_info['plugin_url']);
-            error_log("FTS pluginUpdaterCheckInit: Plugin " . $plugin_identifier . " is " . ($is_active ? 'ACTIVE' : 'INACTIVE'));
 
             if ($is_active) {
 
@@ -217,9 +210,6 @@ class UpdaterCheckInit {
                     'author' => $this->updaterOptionsInfo['author']                       // Author of this plugin
                 );
 
-                // Debug logging - remove after testing
-                error_log("FTS UpdaterCheckInit: Creating UpdaterCheckClass for plugin: " . $plugin_info['title'] . " (ID: " . $plugin_identifier . ", Version: " . $plugin_details['version'] . ")");
-                
                 // setup the updater
                 new UpdaterCheckClass($this->updaterOptionsInfo['store_url'], $plugin_info['plugin_url'], $plugin_identifier, $plugin_info['title'], $plugin_details);
             }


### PR DESCRIPTION
= Version 4.3.9 Monday, September 22nd, 2025 =
  * Refactor files to use PSR-4 autoloading standard.
  * Refactor Classes and File Names to use PascalCase and functions to be camelCase.
  * Fix: Settings > General > When deleting cache the cache time option was reset on settings page.
  * Fix: System Info > Cron Job Cache time reported was incorrect.
  * Fix: License Updater > Update notifications and version update description not showing.
  * Remove: Twitter Code.
  * Remove: Convert Legacy Shortcode option.
  * Works with WordPress version 6.8.2