### PR TITLE
4.4.0

### DIFF
--- a/feed-them-social.php
+++ b/feed-them-social.php
@@ -14,13 +14,13 @@
  * Domain Path: /languages
  * Requires at least: WordPress 5.4
  * Tested up to: WordPress 6.8.2
- * Stable tag: 4.3.9
+ * Stable tag: 4.4.0
  * Requires PHP: 7.0
  * Tested PHP: 8.3
  * License: GPLv3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
- * @version    4.3.9
+ * @version    4.4.0
  * @package    FeedThemSocial/Core
  * @copyright  Copyright (c) 2012-2025 SlickRemix
  *
@@ -34,11 +34,11 @@ if ( ! \defined( 'ABSPATH' ) ) {
 }
 
 // Define the plugin version.
-define( 'FTS_CURRENT_VERSION', '4.3.9' );
+define( 'FTS_CURRENT_VERSION', '4.4.0' );
 
 // Require the file that contains the new autoloader and main plugin class.
-require_once __DIR__ . '/LoadPlugin.php';
+require_once __DIR__ . '/LoadPlugin.php'; // NOSONAR - false positive.
 
 // Instantiate the main class to start the plugin.
 // The autoloader will handle all other class dependencies from here.
-new \feedthemsocial\LoadPlugin();
+new \feedthemsocial\LoadPlugin(); // NOSONAR - false positive.

--- a/readme.txt
+++ b/readme.txt
@@ -125,7 +125,7 @@ Log into WordPress dashboard then click **Plugins** > **Add new** > Then under t
 
 == Changelog ==
 = Version 4.4.0 Thursday, September 25th, 2025 =
-  * Fix: Uninstall files was causing issue not allowing plugin to be deleted from plugins page.
+  * Fix: The uninstall file was causing issue not allowing plugin to be deleted from Plugins page.
   * Fix: YouTube Feed > remove http from url types
 
 = Version 4.3.9 Monday, September 22nd, 2025 =


### PR DESCRIPTION
= Version 4.4.0 Thursday, September 25th, 2025 =
  * Fix: The uninstall file was causing issue not allowing plugin to be deleted from Plugins page.
  * Fix: YouTube Feed > remove http from url types